### PR TITLE
Foundation fixes

### DIFF
--- a/contracts/core/Allo.sol
+++ b/contracts/core/Allo.sol
@@ -110,6 +110,8 @@ contract Allo is Transfer, Initializable, Ownable, AccessControl {
 
     event PoolClosed(uint256 indexed poolId);
 
+    event PoolTotalFundingDecreased(uint256 indexed poolId, uint256 prevAmount, uint256 newAmount);
+
     event TreasuryUpdated(address treasury);
 
     event FeePercentageUpdated(uint256 feePercentage);
@@ -424,6 +426,17 @@ contract Allo is Transfer, Initializable, Ownable, AccessControl {
         uint256 amount =
             _token == address(0) ? address(this).balance : IERC20Upgradeable(_token).balanceOf(address(this));
         _transferAmount(_token, _recipient, amount);
+    }
+
+    function decreasePoolTotalFunding(uint256 _poolId, uint256 _amountToDecrease) external {
+        Pool storage pool = pools[_poolId];
+        if (address(pool.strategy) != msg.sender) {
+            revert UNAUTHORIZED();
+        }
+        uint256 oldAmount = pool.amount;
+        uint256 newAmount = oldAmount - _amountToDecrease;
+        pool.amount = newAmount;
+        emit PoolTotalFundingDecreased(_poolId, oldAmount, newAmount);
     }
 
     /// ====================================

--- a/contracts/strategies/BaseStrategy.sol
+++ b/contracts/strategies/BaseStrategy.sol
@@ -12,9 +12,9 @@ abstract contract BaseStrategy is IStrategy, Transfer {
     /// === Storage Variables ====
     /// ==========================
 
-    Allo private immutable allo;
-    uint256 private poolId;
-    string private strategyName;
+    Allo immutable allo;
+    uint256 poolId;
+    string strategyName;
 
     /// ====================================
     /// ========== Constructor =============

--- a/contracts/strategies/BaseStrategy.sol
+++ b/contracts/strategies/BaseStrategy.sol
@@ -12,9 +12,9 @@ abstract contract BaseStrategy is IStrategy, Transfer {
     /// === Storage Variables ====
     /// ==========================
 
-    Allo immutable allo;
-    uint256 poolId;
-    string strategyName;
+    Allo internal immutable allo;
+    uint256 internal poolId;
+    string internal strategyName;
 
     /// ====================================
     /// ========== Constructor =============

--- a/contracts/strategies/BaseStrategy.sol
+++ b/contracts/strategies/BaseStrategy.sol
@@ -70,7 +70,7 @@ abstract contract BaseStrategy is IStrategy, Transfer {
     /// @param _poolId Id of the pool
     /// @param _data The data to be decoded
     /// @dev This function is called by Allo.sol
-    function initialize(uint256 _poolId, bytes memory _data) external virtual onlyAllo {
+    function initialize(uint256 _poolId, bytes memory _data) public virtual onlyAllo {
         if (_poolId == 0) {
             revert BaseStrategy_INVALID_ADDRESS();
         }


### PR DESCRIPTION
`private` variables can't be read by contracts that inherit them. I removed that from BaseStrategy so strategies can access these variables.

Also changed `initialize()` to public from external so strategies can call `super.initialize()`.