### PR TITLE
Added shared test files

### DIFF
--- a/test/foundry/core/Registry.t.sol
+++ b/test/foundry/core/Registry.t.sol
@@ -1,12 +1,15 @@
-pragma solidity ^0.8.19;
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.19;
 
 import "forge-std/Test.sol";
+import "../shared/RegistrySetup.sol";
+
 import {Registry} from "../../../contracts/core/Registry.sol";
 import {IRegistry} from "../../../contracts/core/IRegistry.sol";
 import {Metadata} from "../../../contracts/core/libraries/Metadata.sol";
 import {TestUtilities} from "../utils/TestUtilities.sol";
 
-contract RegistryTest is Test {
+contract RegistryTest is Test, RegistrySetup {
     event IdentityCreated(
         bytes32 indexed identityId, uint256 nonce, string name, Metadata metadata, address owner, address anchor
     );
@@ -16,34 +19,15 @@ contract RegistryTest is Test {
     event IdentityOwnerUpdated(bytes32 indexed identityId, address owner);
     event IdentityPendingOwnerUpdated(bytes32 indexed identityId, address pendingOwner);
 
-    Registry public registry;
-
-    address public owner;
-    address public member1;
-    address public member2;
-    address[] public members;
-    address public notAMember;
-
     Metadata public metadata;
     string public name;
     uint256 public nonce;
 
     function setUp() public {
-        notAMember = makeAddr("notAMember");
-
-        owner = makeAddr("owner");
-        member1 = makeAddr("member1");
-        member2 = makeAddr("member2");
-
+        __RegistrySetup();
         metadata = Metadata({protocol: 1, pointer: "test metadata"});
         name = "New Identity";
         nonce = 2;
-
-        registry = new Registry(owner);
-
-        members = new address[](2);
-        members[0] = member1;
-        members[1] = member2;
     }
 
     function test_createIdentity() public {
@@ -52,13 +36,13 @@ contract RegistryTest is Test {
         bytes32 testIdentityId = TestUtilities._testUtilGenerateIdentityId(nonce, address(this));
         address testAnchor = TestUtilities._testUtilGenerateAnchor(testIdentityId, name);
 
-        emit IdentityCreated(testIdentityId, nonce, name, metadata, owner, testAnchor);
+        emit IdentityCreated(testIdentityId, nonce, name, metadata, identity1_owner(), testAnchor);
 
         // create identity
-        bytes32 newIdentityId = registry.createIdentity(nonce, name, metadata, owner, members);
+        bytes32 newIdentityId = registry().createIdentity(nonce, name, metadata, identity1_owner(), identity1_members());
 
         // Check if the new identity was created
-        Registry.Identity memory identity = registry.getIdentityById(newIdentityId);
+        Registry.Identity memory identity = registry().getIdentityById(newIdentityId);
 
         assertEq(testIdentityId, newIdentityId, "identityId");
 
@@ -66,38 +50,38 @@ contract RegistryTest is Test {
         assertEq(identity.name, name, "name");
         assertEq(identity.metadata.protocol, metadata.protocol, "metadata.protocol");
         assertEq(identity.metadata.pointer, metadata.pointer, "metadata.pointer");
-        assertEq(registry.anchorToIdentityId(identity.anchor), newIdentityId, "anchorToIdentityId");
+        assertEq(registry().anchorToIdentityId(identity.anchor), newIdentityId, "anchorToIdentityId");
 
-        Registry.Identity memory identityByAnchor = registry.getIdentityByAnchor(identity.anchor);
+        Registry.Identity memory identityByAnchor = registry().getIdentityByAnchor(identity.anchor);
         assertEq(identityByAnchor.name, name, "getIdentityByAnchor: name");
     }
 
     function testRevert_createIdentity_NONCE_NOT_AVAILABLE() public {
         // create identity
-        registry.createIdentity(nonce, name, metadata, owner, members);
+        registry().createIdentity(nonce, name, metadata, identity1_owner(), identity1_members());
 
         vm.expectRevert(IRegistry.NONCE_NOT_AVAILABLE.selector);
 
         // create identity with same index and name
-        registry.createIdentity(nonce, name, metadata, owner, members);
+        registry().createIdentity(nonce, name, metadata, identity1_owner(), identity1_members());
     }
 
     function test_updateIdentityName() public {
-        bytes32 newIdentityId = registry.createIdentity(nonce, name, metadata, owner, members);
+        bytes32 newIdentityId = registry().createIdentity(nonce, name, metadata, identity1_owner(), identity1_members());
 
         string memory newName = "New Name";
         address testAnchor = TestUtilities._testUtilGenerateAnchor(newIdentityId, newName);
         vm.expectEmit(true, false, false, true);
         emit IdentityNameUpdated(newIdentityId, newName, testAnchor);
-        Registry.Identity memory identity = registry.getIdentityById(newIdentityId);
+        Registry.Identity memory identity = registry().getIdentityById(newIdentityId);
 
-        vm.prank(owner);
-        address newAnchor = registry.updateIdentityName(newIdentityId, newName);
+        vm.prank(identity1_owner());
+        address newAnchor = registry().updateIdentityName(newIdentityId, newName);
 
-        assertEq(registry.getIdentityById(newIdentityId).name, newName, "name");
+        assertEq(registry().getIdentityById(newIdentityId).name, newName, "name");
         // old and new anchor should be mapped to identityId
-        assertEq(registry.anchorToIdentityId(identity.anchor), bytes32(0), "old anchor");
-        assertEq(registry.anchorToIdentityId(newAnchor), newIdentityId, "new anchor");
+        assertEq(registry().anchorToIdentityId(identity.anchor), bytes32(0), "old anchor");
+        assertEq(registry().anchorToIdentityId(newAnchor), newIdentityId, "new anchor");
     }
 
     function testRevert_updateIdentityNameForInvalidId() public {
@@ -106,44 +90,44 @@ contract RegistryTest is Test {
 
         vm.expectRevert(IRegistry.UNAUTHORIZED.selector);
 
-        vm.prank(owner);
-        registry.updateIdentityName(invalidIdentityId, newName);
+        vm.prank(identity1_owner());
+        registry().updateIdentityName(invalidIdentityId, newName);
     }
 
     function testRevert_updateIdentityName_UNAUTHORIZED() public {
-        bytes32 newIdentityId = registry.createIdentity(nonce, name, metadata, owner, members);
+        bytes32 newIdentityId = registry().createIdentity(nonce, name, metadata, identity1_owner(), identity1_members());
 
         vm.expectRevert(IRegistry.UNAUTHORIZED.selector);
 
         string memory newName = "New Name";
 
-        vm.prank(member1);
-        registry.updateIdentityName(newIdentityId, newName);
+        vm.prank(identity1_member1());
+        registry().updateIdentityName(newIdentityId, newName);
     }
 
-    function testRevert_updateIdentityName_UNAUTHORIZED_byMember() public {
-        bytes32 newIdentityId = registry.createIdentity(nonce, name, metadata, owner, members);
+    function testRevert_updateIdentityName_UNAUTHORIZED_bymember() public {
+        bytes32 newIdentityId = registry().createIdentity(nonce, name, metadata, identity1_owner(), identity1_members());
 
         vm.expectRevert(IRegistry.UNAUTHORIZED.selector);
 
         string memory newName = "New Name";
 
-        vm.prank(member1);
-        registry.updateIdentityName(newIdentityId, newName);
+        vm.prank(identity1_member1());
+        registry().updateIdentityName(newIdentityId, newName);
     }
 
-    function test_updateIdentityMetadata_byOwner() public {
-        bytes32 newIdentityId = registry.createIdentity(nonce, name, metadata, owner, members);
+    function test_updateIdentityMetadata_byidentity1_owner() public {
+        bytes32 newIdentityId = registry().createIdentity(nonce, name, metadata, identity1_owner(), identity1_members());
 
         Metadata memory newMetadata = Metadata({protocol: 1, pointer: "new metadata"});
 
         vm.expectEmit(true, false, false, true);
         emit IdentityMetadataUpdated(newIdentityId, newMetadata);
 
-        vm.prank(owner);
-        registry.updateIdentityMetadata(newIdentityId, newMetadata);
+        vm.prank(identity1_owner());
+        registry().updateIdentityMetadata(newIdentityId, newMetadata);
 
-        Registry.Identity memory identity = registry.getIdentityById(newIdentityId);
+        Registry.Identity memory identity = registry().getIdentityById(newIdentityId);
         assertEq(identity.metadata.protocol, newMetadata.protocol, "metadata.protocol");
         assertEq(identity.metadata.pointer, newMetadata.pointer, "metadata.pointer");
     }
@@ -153,137 +137,137 @@ contract RegistryTest is Test {
         bytes32 invalidIdentityId = TestUtilities._testUtilGenerateIdentityId(nonce, address(this));
         Metadata memory newMetadata = Metadata({protocol: 1, pointer: "new metadata"});
 
-        vm.prank(owner);
-        registry.updateIdentityMetadata(invalidIdentityId, newMetadata);
+        vm.prank(identity1_owner());
+        registry().updateIdentityMetadata(invalidIdentityId, newMetadata);
     }
 
     function testRevert_updateIdentityMetadata_UNAUTHORIZED() public {
-        bytes32 newIdentityId = registry.createIdentity(nonce, name, metadata, owner, members);
+        bytes32 newIdentityId = registry().createIdentity(nonce, name, metadata, identity1_owner(), identity1_members());
 
         Metadata memory newMetadata = Metadata({protocol: 1, pointer: "new metadata"});
 
         vm.expectRevert(IRegistry.UNAUTHORIZED.selector);
 
-        vm.prank(notAMember);
-        registry.updateIdentityMetadata(newIdentityId, newMetadata);
+        vm.prank(identity1_notAMember());
+        registry().updateIdentityMetadata(newIdentityId, newMetadata);
     }
 
     function test_isOwnerOrMemberOfIdentity() public {
-        bytes32 newIdentityId = registry.createIdentity(nonce, name, metadata, owner, members);
+        bytes32 newIdentityId = registry().createIdentity(nonce, name, metadata, identity1_owner(), identity1_members());
 
-        assertTrue(registry.isOwnerOrMemberOfIdentity(newIdentityId, owner), "isOwner");
-        assertTrue(registry.isOwnerOrMemberOfIdentity(newIdentityId, member1), "isMember");
-        assertFalse(registry.isOwnerOrMemberOfIdentity(newIdentityId, notAMember), "notAMember");
+        assertTrue(registry().isOwnerOrMemberOfIdentity(newIdentityId, identity1_owner()), "isOwner");
+        assertTrue(registry().isOwnerOrMemberOfIdentity(newIdentityId, identity1_member1()), "ismember");
+        assertFalse(registry().isOwnerOrMemberOfIdentity(newIdentityId, identity1_notAMember()), "notAMember");
     }
 
     function test_isOwnerOfIdentity() public {
-        bytes32 newIdentityId = registry.createIdentity(nonce, name, metadata, owner, members);
+        bytes32 newIdentityId = registry().createIdentity(nonce, name, metadata, identity1_owner(), identity1_members());
 
-        assertTrue(registry.isOwnerOfIdentity(newIdentityId, owner), "isOwner");
-        assertFalse(registry.isOwnerOfIdentity(newIdentityId, member1), "notAnOwner");
-        assertFalse(registry.isOwnerOfIdentity(newIdentityId, notAMember), "notAMember");
+        assertTrue(registry().isOwnerOfIdentity(newIdentityId, identity1_owner()), "isOwner");
+        assertFalse(registry().isOwnerOfIdentity(newIdentityId, identity1_member1()), "notAnOwner");
+        assertFalse(registry().isOwnerOfIdentity(newIdentityId, identity1_notAMember()), "notAMember");
     }
 
     function test_isMemberOfIdentity() public {
-        bytes32 newIdentityId = registry.createIdentity(nonce, name, metadata, owner, members);
+        bytes32 newIdentityId = registry().createIdentity(nonce, name, metadata, identity1_owner(), identity1_members());
 
-        assertTrue(registry.isMemberOfIdentity(newIdentityId, member1), "member");
-        assertFalse(registry.isMemberOfIdentity(newIdentityId, notAMember), "notAMember");
+        assertTrue(registry().isMemberOfIdentity(newIdentityId, identity1_member1()), "member");
+        assertFalse(registry().isMemberOfIdentity(newIdentityId, identity1_notAMember()), "notAMember");
     }
 
     function test_addMembers() public {
-        bytes32 newIdentityId = registry.createIdentity(nonce, name, metadata, owner, new address[](0));
+        bytes32 newIdentityId = registry().createIdentity(nonce, name, metadata, identity1_owner(), new address[](0));
 
-        assertFalse(registry.isMemberOfIdentity(newIdentityId, member1), "member1 not added");
-        assertFalse(registry.isMemberOfIdentity(newIdentityId, member2), "member2 not added");
+        assertFalse(registry().isMemberOfIdentity(newIdentityId, identity1_member1()), "member1 not added");
+        assertFalse(registry().isMemberOfIdentity(newIdentityId, identity1_member2()), "member2 not added");
 
-        vm.prank(owner);
-        registry.addMembers(newIdentityId, members);
+        vm.prank(identity1_owner());
+        registry().addMembers(newIdentityId, identity1_members());
 
-        assertTrue(registry.isMemberOfIdentity(newIdentityId, member1), "member1 added");
-        assertTrue(registry.isMemberOfIdentity(newIdentityId, member2), "member2 added");
+        assertTrue(registry().isMemberOfIdentity(newIdentityId, identity1_member1()), "member1 added");
+        assertTrue(registry().isMemberOfIdentity(newIdentityId, identity1_member2()), "member2 added");
     }
 
     function testRevert_addMembers_UNAUTHORIZED() public {
-        bytes32 newIdentityId = registry.createIdentity(nonce, name, metadata, owner, new address[](0));
+        bytes32 newIdentityId = registry().createIdentity(nonce, name, metadata, identity1_owner(), new address[](0));
 
-        vm.prank(member1);
+        vm.prank(identity1_member1());
         vm.expectRevert(IRegistry.UNAUTHORIZED.selector);
-        registry.addMembers(newIdentityId, members);
+        registry().addMembers(newIdentityId, identity1_members());
     }
 
     function test_removeMembers() public {
-        bytes32 newIdentityId = registry.createIdentity(nonce, name, metadata, owner, members);
+        bytes32 newIdentityId = registry().createIdentity(nonce, name, metadata, identity1_owner(), identity1_members());
 
-        assertTrue(registry.isMemberOfIdentity(newIdentityId, member1), "member1 added");
-        assertTrue(registry.isMemberOfIdentity(newIdentityId, member2), "member2 added");
+        assertTrue(registry().isMemberOfIdentity(newIdentityId, identity1_member1()), "member1 added");
+        assertTrue(registry().isMemberOfIdentity(newIdentityId, identity1_member2()), "member2 added");
 
-        vm.prank(owner);
-        registry.removeMembers(newIdentityId, members);
+        vm.prank(identity1_owner());
+        registry().removeMembers(newIdentityId, identity1_members());
 
-        assertFalse(registry.isMemberOfIdentity(newIdentityId, member1), "member1 not added");
-        assertFalse(registry.isMemberOfIdentity(newIdentityId, member2), "member2 not added");
+        assertFalse(registry().isMemberOfIdentity(newIdentityId, identity1_member1()), "member1 not added");
+        assertFalse(registry().isMemberOfIdentity(newIdentityId, identity1_member2()), "member2 not added");
     }
 
     function testRevert_removeMembers_UNAUTHORIZED() public {
-        bytes32 newIdentityId = registry.createIdentity(nonce, name, metadata, owner, new address[](0));
+        bytes32 newIdentityId = registry().createIdentity(nonce, name, metadata, identity1_owner(), new address[](0));
 
-        vm.prank(member1);
+        vm.prank(identity1_member1());
         vm.expectRevert(IRegistry.UNAUTHORIZED.selector);
-        registry.removeMembers(newIdentityId, members);
+        registry().removeMembers(newIdentityId, identity1_members());
     }
 
-    function test_updateIdentityPendingOwner() public {
-        bytes32 newIdentityId = registry.createIdentity(nonce, name, metadata, owner, new address[](0));
+    function test_updateIdentityPendingidentity1_owner() public {
+        bytes32 newIdentityId = registry().createIdentity(nonce, name, metadata, identity1_owner(), new address[](0));
 
         vm.expectEmit(true, false, false, true);
-        emit IdentityPendingOwnerUpdated(newIdentityId, notAMember);
+        emit IdentityPendingOwnerUpdated(newIdentityId, identity1_notAMember());
 
-        vm.prank(owner);
-        registry.updateIdentityPendingOwner(newIdentityId, notAMember);
-        address pendingOwner = registry.identityIdToPendingOwner(newIdentityId);
+        vm.prank(identity1_owner());
+        registry().updateIdentityPendingOwner(newIdentityId, identity1_notAMember());
+        address pendingOwner = registry().identityIdToPendingOwner(newIdentityId);
 
-        assertEq(pendingOwner, notAMember, "after: pendingOwner");
+        assertEq(pendingOwner, identity1_notAMember(), "after: pendingOwner");
     }
 
     function testRevert_updateIdentityPendingOwner_UNAUTHORIZED() public {
-        bytes32 newIdentityId = registry.createIdentity(nonce, name, metadata, owner, new address[](0));
+        bytes32 newIdentityId = registry().createIdentity(nonce, name, metadata, identity1_owner(), new address[](0));
 
-        vm.prank(member1);
+        vm.prank(identity1_member1());
         vm.expectRevert(IRegistry.UNAUTHORIZED.selector);
-        registry.updateIdentityPendingOwner(newIdentityId, notAMember);
+        registry().updateIdentityPendingOwner(newIdentityId, identity1_notAMember());
     }
 
     function test_acceptIdentityOwnership() public {
-        bytes32 newIdentityId = registry.createIdentity(nonce, name, metadata, owner, new address[](0));
+        bytes32 newIdentityId = registry().createIdentity(nonce, name, metadata, identity1_owner(), new address[](0));
 
-        vm.prank(owner);
-        registry.updateIdentityPendingOwner(newIdentityId, notAMember);
+        vm.prank(identity1_owner());
+        registry().updateIdentityPendingOwner(newIdentityId, identity1_notAMember());
 
-        assertTrue(registry.isOwnerOfIdentity(newIdentityId, owner), "before: isOwner");
-        assertFalse(registry.isOwnerOfIdentity(newIdentityId, notAMember), "before: notAnOwner");
-        address pendingOwner = registry.identityIdToPendingOwner(newIdentityId);
-        assertEq(pendingOwner, notAMember, "before: pendingOwner");
+        assertTrue(registry().isOwnerOfIdentity(newIdentityId, identity1_owner()), "before: isOwner");
+        assertFalse(registry().isOwnerOfIdentity(newIdentityId, identity1_notAMember()), "before: notAnOwner");
+        address pendingOwner = registry().identityIdToPendingOwner(newIdentityId);
+        assertEq(pendingOwner, identity1_notAMember(), "before: pendingOwner");
 
         vm.expectEmit(true, false, false, true);
-        emit IdentityOwnerUpdated(newIdentityId, notAMember);
+        emit IdentityOwnerUpdated(newIdentityId, identity1_notAMember());
 
-        vm.prank(notAMember);
-        registry.acceptIdentityOwnership(newIdentityId);
+        vm.prank(identity1_notAMember());
+        registry().acceptIdentityOwnership(newIdentityId);
 
-        assertFalse(registry.isOwnerOfIdentity(newIdentityId, owner), "after: notAnOwner");
-        assertTrue(registry.isOwnerOfIdentity(newIdentityId, notAMember), "after: isOwner");
-        assertEq(registry.identityIdToPendingOwner(newIdentityId), address(0), "after: pendingOwner");
+        assertFalse(registry().isOwnerOfIdentity(newIdentityId, identity1_owner()), "after: notAnOwner");
+        assertTrue(registry().isOwnerOfIdentity(newIdentityId, identity1_notAMember()), "after: isOwner");
+        assertEq(registry().identityIdToPendingOwner(newIdentityId), address(0), "after: pendingOwner");
     }
 
-    function testRevert_acceptIdentityOwnership_NOT_PENDING_OWNER() public {
-        bytes32 newIdentityId = registry.createIdentity(nonce, name, metadata, owner, new address[](0));
+    function testRevert_acceptIdentityOwnership_NOT_PENDING_identity1_owner() public {
+        bytes32 newIdentityId = registry().createIdentity(nonce, name, metadata, identity1_owner(), new address[](0));
 
-        vm.prank(owner);
-        registry.updateIdentityPendingOwner(newIdentityId, notAMember);
+        vm.prank(identity1_owner());
+        registry().updateIdentityPendingOwner(newIdentityId, identity1_notAMember());
 
-        vm.prank(owner);
+        vm.prank(identity1_owner());
         vm.expectRevert(IRegistry.NOT_PENDING_OWNER.selector);
-        registry.acceptIdentityOwnership(newIdentityId);
+        registry().acceptIdentityOwnership(newIdentityId);
     }
 }

--- a/test/foundry/shared/Accounts.sol
+++ b/test/foundry/shared/Accounts.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.19;
+
+import "forge-std/StdCheats.sol";
+
+contract Accounts is StdCheats {
+    // //////////////////////
+    // Protocol adresses
+    // //////////////////////
+
+    function registry_owner() public returns (address) {
+        return makeAddr("registry_owner");
+    }
+
+    function allo_owner() public pure returns (address) {
+        return 0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496;
+    }
+
+    function allo_treasury() public returns (address payable) {
+        return payable(makeAddr("allo_treasury"));
+    }
+
+    // //////////////////////
+    // Null Identity adresses
+    // //////////////////////
+
+    function nullIdentity_owner() public pure returns (address) {
+        return 0x0000000000000000000000000000000000000000;
+    }
+
+    function nullIdentity_notAMember() public pure returns (address) {
+        return 0x0000000000000000000000000000000000000000;
+    }
+
+    function nullIdentity_member1() public pure returns (address) {
+        return 0x0000000000000000000000000000000000000000;
+    }
+
+    function nullIdentity_member2() public pure returns (address) {
+        return 0x0000000000000000000000000000000000000000;
+    }
+
+    function nullIdentity_members() public pure returns (address[] memory) {
+        return new address[](2);
+    }
+
+    // //////////////////////
+    // Pool adresses
+    // //////////////////////
+
+    function pool_admin() public returns (address) {
+        return makeAddr("pool_admin");
+    }
+
+    function pool_notAManager() public returns (address) {
+        return makeAddr("pool_notAManager");
+    }
+
+    function pool_manager1() public returns (address) {
+        return makeAddr("pool_manager1");
+    }
+
+    function pool_manager2() public returns (address) {
+        return makeAddr("pool_manager2");
+    }
+
+    function pool_managers() public returns (address[] memory) {
+        address[] memory _members = new address[](2);
+        _members[0] = pool_manager1();
+        _members[1] = pool_manager2();
+
+        return _members;
+    }
+
+    // //////////////////////
+    // Identity 1 adresses
+    // //////////////////////
+
+    function identity1_owner() public returns (address) {
+        return makeAddr("identity1_owner");
+    }
+
+    function identity1_notAMember() public returns (address) {
+        return makeAddr("identity1_notAMember");
+    }
+
+    function identity1_member1() public returns (address) {
+        return makeAddr("identity1_member1");
+    }
+
+    function identity1_member2() public returns (address) {
+        return makeAddr("identity1_member2");
+    }
+
+    function identity1_members() public returns (address[] memory) {
+        address[] memory _members = new address[](2);
+        _members[0] = identity1_member1();
+        _members[1] = identity1_member2();
+
+        return _members;
+    }
+
+    // //////////////////////
+    // Identity 2 adresses
+    // //////////////////////
+
+    function identity2_owner() public returns (address) {
+        return makeAddr("identity2_owner");
+    }
+
+    function identity2_notAMember() public returns (address) {
+        return makeAddr("identity2_notAMember");
+    }
+
+    function identity2_member1() public returns (address) {
+        return makeAddr("identity2_member1");
+    }
+
+    function identity2_member2() public returns (address) {
+        return makeAddr("identity2_member2");
+    }
+
+    function identity2_members() public returns (address[] memory) {
+        address[] memory _members = new address[](2);
+        _members[0] = identity2_member1();
+        _members[1] = identity2_member2();
+
+        return _members;
+    }
+}

--- a/test/foundry/shared/AlloSetup.sol
+++ b/test/foundry/shared/AlloSetup.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.19;
+
+import {Allo} from "../../../contracts/core/Allo.sol";
+import {Accounts} from "./Accounts.sol";
+
+contract AlloSetup is Accounts {
+    Allo internal _allo_;
+
+    function __AlloSetup(address _registry) internal {
+        _allo_ = new Allo();
+
+        _allo_.initialize(
+            _registry, // _registry
+            allo_treasury(), // _treasury
+            1e16, // _feePercentage
+            0, // _baseFee
+            0 // _feeSkirtingBountyPercentage
+        );
+    }
+
+    function allo() public view returns (Allo) {
+        return _allo_;
+    }
+}

--- a/test/foundry/shared/RegistrySetup.sol
+++ b/test/foundry/shared/RegistrySetup.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.19;
+
+import "forge-std/Test.sol";
+
+import {Registry} from "../../../contracts/core/Registry.sol";
+import {Metadata} from "../../../contracts/core/libraries/Metadata.sol";
+import {Accounts} from "./Accounts.sol";
+
+/// @title RegistrySetup
+/// @notice This contract is used to setup an empty Registry contract for testing purposes.
+contract RegistrySetup is Test, Accounts {
+    Registry internal _registry_;
+
+    function __RegistrySetup() internal {
+        _registry_ = new Registry(registry_owner());
+    }
+
+    function registry() public view returns (Registry) {
+        return _registry_;
+    }
+}
+
+/// @title RegistrySetupFull
+/// @notice This contract is used to setup a Registry contract with two identities for testing purposes.
+contract RegistrySetupFull is RegistrySetup {
+    bytes32 internal _poolIdentityId_;
+    address internal _poolItyAnchor_;
+
+    bytes32 internal _identity1Id_;
+    address internal _identity1Anchor_;
+
+    bytes32 internal _identity2Id_;
+    address internal _identity2Anchor_;
+
+    function __RegistrySetupFull() internal {
+        __RegistrySetup();
+
+        vm.prank(pool_admin());
+        _poolIdentityId_ = _registry_.createIdentity(
+            0, "Pool Identity 1", Metadata({protocol: 1, pointer: "PoolIdentity1"}), pool_admin(), pool_managers()
+        );
+
+        _poolItyAnchor_ = _registry_.getIdentityById(_poolIdentityId_).anchor;
+
+        vm.prank(identity1_owner());
+        _identity1Id_ = _registry_.createIdentity(
+            0, "Identity 1", Metadata({protocol: 1, pointer: "Identity1"}), identity1_owner(), identity1_members()
+        );
+        _identity1Anchor_ = _registry_.getIdentityById(_identity1Id_).anchor;
+
+        vm.prank(identity2_owner());
+        _identity2Id_ = _registry_.createIdentity(
+            0, "Identity 2", Metadata({protocol: 1, pointer: "Identity2"}), identity2_owner(), identity2_members()
+        );
+        _identity2Anchor_ = _registry_.getIdentityById(_identity2Id_).anchor;
+    }
+
+    function poolIdentity_id() public view returns (bytes32) {
+        return _poolIdentityId_;
+    }
+
+    function poolIdentity_anchor() public view returns (address) {
+        return _poolItyAnchor_;
+    }
+
+    function identity1_id() public view returns (bytes32) {
+        return _identity1Id_;
+    }
+
+    function identity1_anchor() public view returns (address) {
+        return _identity1Anchor_;
+    }
+
+    function identity2_id() public view returns (bytes32) {
+        return _identity2Id_;
+    }
+
+    function identity2_anchor() public view returns (address) {
+        return _identity2Anchor_;
+    }
+}

--- a/test/foundry/strategies/QVSimpleStrategy.t.sol
+++ b/test/foundry/strategies/QVSimpleStrategy.t.sol
@@ -2,13 +2,14 @@ pragma solidity 0.8.19;
 
 import "forge-std/Test.sol";
 
-import {BaseStrategy} from "../../../contracts/strategies/BaseStrategy.sol";
+import {Accounts} from "../shared/Accounts.sol";
+import {RegistrySetupFull} from "../shared/RegistrySetup.sol";
+import {AlloSetup} from "../shared/AlloSetup.sol";
+
 import {QVSimpleStrategy} from "../../../contracts/strategies/qv-simple/QVSimpleStrategy.sol";
 import {Metadata} from "../../../contracts/core/libraries/Metadata.sol";
-import {Allo} from "../../../contracts/core/Allo.sol";
-import {Registry} from "../../../contracts/core/Registry.sol";
 
-contract QVSimpleStrategyTest is Test {
+contract QVSimpleStrategyTest is Test, Accounts, RegistrySetupFull, AlloSetup {
     error ALLOCATION_NOT_ACTIVE();
 
     enum InternalRecipientStatus {
@@ -44,31 +45,23 @@ contract QVSimpleStrategyTest is Test {
     uint256 public allocationStartTime;
     uint256 public allocationEndTime;
 
-    Allo public allo;
-    Registry public registry;
     QVSimpleStrategy public strategy;
-
-    address public alloOwner;
-    address public owner;
-    address public member1;
-    address public member2;
-    address[] public members;
-    address payable public treasury;
 
     address public token;
 
-    Metadata public metadata;
-    string public name;
-    uint256 public nonce;
+    Metadata public poolMetadata;
+
     uint256 public poolId;
 
-    bytes32 public identityId;
     bool public initialized;
 
     event Appealed(address indexed recipientId, bytes data, address sender);
     event Reviewed(address indexed recipientId, InternalRecipientStatus status, address sender);
 
     function setUp() public {
+        __RegistrySetupFull();
+        __AlloSetup(address(registry()));
+
         registrationStartTime = block.timestamp;
         registrationEndTime = block.timestamp + 300;
         allocationStartTime = block.timestamp + 301;
@@ -77,39 +70,16 @@ contract QVSimpleStrategyTest is Test {
         registryGating = false;
         metadataRequired = false;
 
-        alloOwner = 0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496;
-        owner = makeAddr("owner");
-
-        allo = new Allo();
-
-        member1 = makeAddr("member1");
-        member2 = makeAddr("member2");
-
-        metadata = Metadata({protocol: 1, pointer: "test metadata"});
-        name = "New Identity";
-        nonce = 2;
-
-        registry = new Registry(owner);
-        treasury = payable(makeAddr("treasury"));
-        allo.initialize(address(registry), treasury, 1e16, 0, 0);
-
-        members = new address[](3);
-        members[0] = member1;
-        members[1] = member2;
-
-        members[2] = owner;
-
-        allo.updateTreasury(treasury);
+        poolMetadata = Metadata({protocol: 1, pointer: "PoolMetadata"});
 
         // todo: setup strategy
-        strategy = new QVSimpleStrategy(address(allo), "QVSimpleStrategy");
+        strategy = new QVSimpleStrategy(address(allo()), "QVSimpleStrategy");
 
-        identityId = registry.createIdentity(nonce, name, metadata, owner, members);
         initialized = false;
 
-        vm.prank(owner);
-        poolId = allo.createPoolWithCustomStrategy(
-            identityId,
+        vm.prank(pool_admin());
+        poolId = allo().createPoolWithCustomStrategy(
+            poolIdentity_id(),
             address(strategy),
             abi.encode(
                 registryGating,
@@ -122,8 +92,8 @@ contract QVSimpleStrategyTest is Test {
             ),
             address(0),
             0,
-            metadata,
-            members
+            poolMetadata,
+            pool_managers()
         );
     }
 
@@ -183,7 +153,7 @@ contract QVSimpleStrategyTest is Test {
 
         bytes memory data = abi.encode(recipientId, voiceCreditsToAllocate);
 
-        allo.allocate(1, data);
+        allo().allocate(1, data);
     }
 
     function testRevert_allocate_UNAUTHORIZED() public {}


### PR DESCRIPTION
This pull request introduces a set of shared Solidity files for testing.
Now, rather than configuring `Allo` and the `Registry` with multiple accounts in each strategy test file, we can effortlessly import these shared contracts and invoke the init functions and everything is set up.

Also I added predefined accounts that can be directly utilized without the need to create new addresses in any test file. 