### PR TITLE
Minimal Anchor Address Implementation

### DIFF
--- a/contracts/core/Anchor.sol
+++ b/contracts/core/Anchor.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.19;
+
+import {Registry} from "./Registry.sol";
+
+contract Anchor {
+    /// ==========================
+    /// === Storage Variables ====
+    /// ==========================
+    Registry immutable registry;
+    bytes32 public identityId;
+
+    /// ==========================
+    /// ======== Errors ==========
+    /// ==========================
+    error UNAUTHORIZED();
+    error ALREADY_INITIALIZED();
+    error CALL_FAILED();
+
+    /// ==========================
+    /// ======= Constructor ======
+    /// ==========================
+    constructor(address _registry) {
+        registry = Registry(_registry);
+    }
+
+    /// ==========================
+    /// ======== External ========
+    /// ==========================
+
+    /// @notice Initialize the Anchor
+    /// @param _identityId The identityId of the identity to anchor
+    function initialize(bytes32 _identityId) external {
+        if (msg.sender != address(registry)) {
+            revert UNAUTHORIZED();
+        }
+
+        if (identityId != "") {
+            revert ALREADY_INITIALIZED();
+        }
+        identityId = _identityId;
+    }
+
+    /// @notice Execute a call to a target address
+    /// @param _target The target address to call
+    /// @param _value The amount of native token to send
+    /// @param _data The data to send to the target address
+    function execute(address _target, uint256 _value, bytes memory _data) external returns (bytes memory) {
+        if (!registry.isOwnerOfIdentity(identityId, msg.sender)) {
+            revert UNAUTHORIZED();
+        }
+
+        (bool success, bytes memory data) = _target.call{value: _value}(_data);
+        if (!success) {
+            revert CALL_FAILED();
+        }
+        return data;
+    }
+}

--- a/contracts/core/Anchor.sol
+++ b/contracts/core/Anchor.sol
@@ -7,39 +7,26 @@ contract Anchor {
     /// ==========================
     /// === Storage Variables ====
     /// ==========================
-    Registry immutable registry;
+    Registry public immutable registry;
     bytes32 public identityId;
 
     /// ==========================
     /// ======== Errors ==========
     /// ==========================
     error UNAUTHORIZED();
-    error ALREADY_INITIALIZED();
     error CALL_FAILED();
 
     /// ==========================
     /// ======= Constructor ======
     /// ==========================
-    constructor(address _registry) {
-        registry = Registry(_registry);
+    constructor(bytes32 _identityId) {
+        registry = Registry(msg.sender);
+        identityId = _identityId;
     }
 
     /// ==========================
     /// ======== External ========
     /// ==========================
-
-    /// @notice Initialize the Anchor
-    /// @param _identityId The identityId of the identity to anchor
-    function initialize(bytes32 _identityId) external {
-        if (msg.sender != address(registry)) {
-            revert UNAUTHORIZED();
-        }
-
-        if (identityId != "") {
-            revert ALREADY_INITIALIZED();
-        }
-        identityId = _identityId;
-    }
 
     /// @notice Execute a call to a target address
     /// @param _target The target address to call

--- a/contracts/core/Registry.sol
+++ b/contracts/core/Registry.sol
@@ -257,15 +257,12 @@ contract Registry is IRegistry, Native, AccessControl, Transfer {
     /// @notice Generates and deploy the anchor for the given identityId and name
     /// @param _identityId Id of the identity
     /// @param _name The name of the identity
-    function _generateAnchor(bytes32 _identityId, string memory _name) internal returns (address) {
+    function _generateAnchor(bytes32 _identityId, string memory _name) internal returns (address anchor) {
         bytes32 salt = keccak256(abi.encodePacked(_identityId, _name));
 
-        bytes memory creationCode = abi.encodePacked(type(Anchor).creationCode, abi.encode(address(this)));
+        bytes memory creationCode = abi.encodePacked(type(Anchor).creationCode, abi.encode(_identityId));
 
-        address anchor = CREATE3.deploy(salt, creationCode, 0);
-        Anchor(anchor).initialize(_identityId);
-
-        return anchor;
+        anchor = CREATE3.deploy(salt, creationCode, 0);
     }
 
     /// @notice Generates the identityId based on msg.sender

--- a/contracts/core/Registry.sol
+++ b/contracts/core/Registry.sol
@@ -140,7 +140,10 @@ contract Registry is IRegistry, Native, AccessControl, Transfer {
         Identity storage identity = identitiesById[_identityId];
         identity.name = _name;
 
-        // set new anchor while preserving old anchor
+        // remove old anchor
+        anchorToIdentityId[identity.anchor] = bytes32(0);
+
+        // set new anchor
         identity.anchor = anchor;
         anchorToIdentityId[anchor] = _identityId;
 

--- a/contracts/core/Registry.sol
+++ b/contracts/core/Registry.sol
@@ -3,10 +3,12 @@ pragma solidity 0.8.19;
 
 // External Libraries
 import {AccessControl} from "@openzeppelin/access/AccessControl.sol";
+import {CREATE3} from "@solady/utils/CREATE3.sol";
 import {ERC20} from "@solady/tokens/ERC20.sol";
 // Interfaces
 import "./IRegistry.sol";
 // Internal Libraries
+import {Anchor} from "./Anchor.sol";
 import {Metadata} from "./libraries/Metadata.sol";
 import "./libraries/Native.sol";
 import "./libraries/Transfer.sol";
@@ -138,10 +140,7 @@ contract Registry is IRegistry, Native, AccessControl, Transfer {
         Identity storage identity = identitiesById[_identityId];
         identity.name = _name;
 
-        // clear old anchor
-        anchorToIdentityId[identity.anchor] = bytes32(0);
-
-        // set new anchor
+        // set new anchor while preserving old anchor
         identity.anchor = anchor;
         anchorToIdentityId[anchor] = _identityId;
 
@@ -252,12 +251,18 @@ contract Registry is IRegistry, Native, AccessControl, Transfer {
     /// ======== Internal Functions ========
     /// ====================================
 
-    /// @notice Generates the anchor for the given identityId and name
+    /// @notice Generates and deploy the anchor for the given identityId and name
     /// @param _identityId Id of the identity
     /// @param _name The name of the identity
-    function _generateAnchor(bytes32 _identityId, string memory _name) internal pure returns (address) {
-        bytes32 attestationHash = keccak256(abi.encodePacked(_identityId, _name));
-        return address(uint160(uint256(attestationHash)));
+    function _generateAnchor(bytes32 _identityId, string memory _name) internal returns (address) {
+        bytes32 salt = keccak256(abi.encodePacked(_identityId, _name));
+
+        bytes memory creationCode = abi.encodePacked(type(Anchor).creationCode, abi.encode(address(this)));
+
+        address anchor = CREATE3.deploy(salt, creationCode, 0);
+        Anchor(anchor).initialize(_identityId);
+
+        return anchor;
     }
 
     /// @notice Generates the identityId based on msg.sender

--- a/test/foundry/core/Anchor.t.sol
+++ b/test/foundry/core/Anchor.t.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.19;
+
+import "forge-std/Test.sol";
+import {Anchor} from "../../../contracts/core/Anchor.sol";
+
+// Mock Registry contract
+contract MockRegistry {
+    mapping(bytes32 => address) public owners;
+
+    function isOwnerOfIdentity(bytes32 identityId, address owner) external view returns (bool) {
+        return owners[identityId] == owner;
+    }
+
+    function setOwnerOfIdentity(bytes32 identityId, address owner) external {
+        owners[identityId] = owner;
+    }
+}
+
+contract AnchorTest is Test {
+    Anchor public anchor;
+    MockRegistry public mockRegistry;
+
+    function setUp() public {
+        mockRegistry = new MockRegistry();
+        anchor = new Anchor(address(mockRegistry));
+    }
+
+    function test_deploy() public {
+        anchor = new Anchor(address(mockRegistry));
+    }
+
+    function test_initialize() public {
+        bytes32 identityId = bytes32("test_identity");
+
+        // Only the registry contract should be able to initialize the anchor
+        assertTrue(anchor.identityId() == bytes32(0)); // Check if identityId is not initialized yet
+
+        mockRegistry.setOwnerOfIdentity(identityId, address(this)); // Set the caller as the owner of the identity
+
+        vm.prank(address(mockRegistry)); // Prank the registry contract to make it think it's the caller
+        anchor.initialize(identityId); // Initialize the anchor
+        assertTrue(anchor.identityId() == identityId); // Check if identityId is set after initialization
+    }
+
+    function testRevert_initialize_UNAUTHORIZED() public {
+        bytes32 identityId = bytes32("test_identity");
+
+        vm.expectRevert(Anchor.UNAUTHORIZED.selector); // Expect a revert with the UNAUTHORIZED error
+        anchor.initialize(identityId); // Try to initialize the anchor from an unauthorized address
+    }
+
+    function testRevert_initialize_ALREADY_INITIALIZED() public {
+        bytes32 identityId = bytes32("test_identity");
+
+        // Only the registry contract should be able to initialize the anchor
+        assertTrue(anchor.identityId() == bytes32(0)); // Check if identityId is not initialized yet
+        mockRegistry.setOwnerOfIdentity(identityId, address(this)); // Set the caller as the owner of the identity
+
+        vm.prank(address(mockRegistry)); // Prank the registry contract to make it think it's the caller
+        anchor.initialize(identityId); // Initialize the anchor
+        assertTrue(anchor.identityId() == identityId); // Check if identityId is set after initialization
+
+        vm.expectRevert(Anchor.ALREADY_INITIALIZED.selector); // Expect a revert with the ALREADY_INITIALIZED error
+
+        // Try to initialize the anchor again with a different identityId (should revert)
+        vm.prank(address(mockRegistry)); // Prank the registry contract to make it think it's the caller
+        bytes32 identityId2 = bytes32("test_identity_2");
+        anchor.initialize(identityId2);
+    }
+
+    function test_execute() public {
+        vm.prank(address(mockRegistry)); // Prank the registry contract to make it think it's the caller
+        bytes32 identityId = bytes32("test_identity");
+        anchor.initialize(identityId);
+
+        mockRegistry.setOwnerOfIdentity(identityId, address(this)); // Set the caller as the owner of the identity
+
+        // Deploy a simple contract that increments a value and return it
+        Incrementer incrementer = new Incrementer();
+        uint256 initialValue = incrementer.getValue();
+
+        // Execute a call to increment the value by 10
+        bytes memory data = abi.encodeWithSignature("increment(uint256)", 10);
+        anchor.execute(address(incrementer), 0, data);
+
+        // Check if the value has been incremented
+        uint256 finalValue = incrementer.getValue();
+        assertTrue(finalValue == initialValue + 10);
+    }
+
+    function test_execute_UNAUTHORIZED() public {
+        // Deploy a simple contract that increments a value and return it
+        Incrementer incrementer = new Incrementer();
+
+        vm.expectRevert(Anchor.UNAUTHORIZED.selector); // Expect a revert with the UNAUTHORIZED error
+
+        // Execute a call to increment the value by 10 from an unauthorized address (should revert)
+        bytes memory data = abi.encodeWithSignature("increment(uint256)", 10);
+        anchor.execute(address(incrementer), 0, data);
+    }
+
+    function test_execute_CALL_FAILED() public {
+        vm.prank(address(mockRegistry)); // Prank the registry contract to make it think it's the caller
+        bytes32 identityId = bytes32("test_identity");
+        anchor.initialize(identityId);
+
+        mockRegistry.setOwnerOfIdentity(identityId, address(this)); // Set the caller as the owner of the identity
+        // Deploy a contract without a fallback function (cannot receive ETH)
+        NoFallbackContract noFallback = new NoFallbackContract();
+
+        vm.expectRevert(Anchor.CALL_FAILED.selector); // Expect a revert with the CALL_FAILED error
+        // Try to execute a call to the contract (should revert because the call will fail)
+        bytes memory data = abi.encodeWithSignature("someFunction()");
+        anchor.execute(address(noFallback), 1 ether, data);
+    }
+}
+
+// Simple contract with a single function to increment a value
+contract Incrementer {
+    uint256 public value;
+
+    function increment(uint256 amount) external {
+        value += amount;
+    }
+
+    function getValue() external view returns (uint256) {
+        return value;
+    }
+}
+
+// Simple contract without a fallback function (cannot receive ETH)
+contract NoFallbackContract {
+// This contract intentionally does not have a fallback function
+}

--- a/test/foundry/core/Registry.t.sol
+++ b/test/foundry/core/Registry.t.sol
@@ -100,7 +100,7 @@ contract RegistryTest is Test, RegistrySetup {
 
         assertEq(registry().getIdentityById(newIdentityId).name, newName, "name");
         // old and new anchor should be mapped to identityId
-        assertEq(registry().anchorToIdentityId(identity.anchor), newIdentityId, "old anchor");
+        assertEq(registry().anchorToIdentityId(identity.anchor), bytes32(0), "old anchor");
         assertEq(registry().anchorToIdentityId(newAnchor), newIdentityId, "new anchor");
     }
 

--- a/test/foundry/core/Registry.t.sol
+++ b/test/foundry/core/Registry.t.sol
@@ -39,7 +39,7 @@ contract RegistryTest is Test, RegistrySetup {
         vm.expectEmit(true, false, false, true);
 
         bytes32 testIdentityId = TestUtilities._testUtilGenerateIdentityId(nonce, address(this));
-        address testAnchor = TestUtilities._testUtilGenerateAnchor(testIdentityId, name);
+        address testAnchor = TestUtilities._testUtilGenerateAnchor(testIdentityId, name, address(registry()));
 
         emit IdentityCreated(testIdentityId, nonce, name, metadata, identity1_owner(), testAnchor);
 
@@ -90,7 +90,7 @@ contract RegistryTest is Test, RegistrySetup {
         bytes32 newIdentityId = registry().createIdentity(nonce, name, metadata, identity1_owner(), identity1_members());
 
         string memory newName = "New Name";
-        address testAnchor = TestUtilities._testUtilGenerateAnchor(newIdentityId, newName);
+        address testAnchor = TestUtilities._testUtilGenerateAnchor(newIdentityId, newName, address(registry()));
         vm.expectEmit(true, false, false, true);
         emit IdentityNameUpdated(newIdentityId, newName, testAnchor);
         Registry.Identity memory identity = registry().getIdentityById(newIdentityId);
@@ -100,7 +100,7 @@ contract RegistryTest is Test, RegistrySetup {
 
         assertEq(registry().getIdentityById(newIdentityId).name, newName, "name");
         // old and new anchor should be mapped to identityId
-        assertEq(registry().anchorToIdentityId(identity.anchor), bytes32(0), "old anchor");
+        assertEq(registry().anchorToIdentityId(identity.anchor), newIdentityId, "old anchor");
         assertEq(registry().anchorToIdentityId(newAnchor), newIdentityId, "new anchor");
     }
 

--- a/test/foundry/utils/TestUtilities.sol
+++ b/test/foundry/utils/TestUtilities.sol
@@ -1,19 +1,57 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.19;
 
+// External Libraries
 library TestUtilities {
     /// @notice Generates the anchor for the given identityId and name
     /// @param _identityId Id of the identity
     /// @param _name The name of the identity
-    function _testUtilGenerateAnchor(bytes32 _identityId, string memory _name) internal pure returns (address) {
-        bytes32 attestationHash = keccak256(abi.encodePacked(_identityId, _name));
+    function _testUtilGenerateAnchor(bytes32 _identityId, string memory _name, address _registry)
+        internal
+        pure
+        returns (address)
+    {
+        bytes32 salt = keccak256(abi.encodePacked(_identityId, _name));
 
-        return address(uint160(uint256(attestationHash)));
+        return getDeployed(salt, _registry);
     }
 
     /// @notice Generates the identityId based on msg.sender
     /// @param _nonce Nonce used to generate identityId
     function _testUtilGenerateIdentityId(uint256 _nonce, address sender) internal pure returns (bytes32) {
         return keccak256(abi.encodePacked(_nonce, sender));
+    }
+
+    /// @dev Returns the deterministic address for `salt`.
+    function getDeployed(bytes32 salt, address registry) internal pure returns (address deployed) {
+        /// @dev Hash of the `_PROXY_BYTECODE`.
+        /// Equivalent to `keccak256(abi.encodePacked(hex"67363d3d37363d34f03d5260086018f3"))`.
+        bytes32 _PROXY_BYTECODE_HASH = 0x21c35dbe1b344a2488cf3321d6ce542f8e9f305544ff09e4993a62319a497c1f;
+
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Cache the free memory pointer.
+            let m := mload(0x40)
+            // Store `address(this)`.
+            mstore(0x00, registry)
+            // Store the prefix.
+            mstore8(0x0b, 0xff)
+            // Store the salt.
+            mstore(0x20, salt)
+            // Store the bytecode hash.
+            mstore(0x40, _PROXY_BYTECODE_HASH)
+
+            // Store the proxy's address.
+            mstore(0x14, keccak256(0x0b, 0x55))
+            // Restore the free memory pointer.
+            mstore(0x40, m)
+            // 0xd6 = 0xc0 (short RLP prefix) + 0x16 (length of: 0x94 ++ proxy ++ 0x01).
+            // 0x94 = 0x80 + 0x14 (0x14 = the length of an address, 20 bytes, in hex).
+            mstore(0x00, 0xd694)
+            // Nonce of the proxy contract (1).
+            mstore8(0x34, 0x01)
+
+            deployed := keccak256(0x1e, 0x17)
+        }
     }
 }


### PR DESCRIPTION
Here's a simple implementation of the Anchor.

A few important things to note:
- This should be deployed once and then clones should be put in front of it for each individual deployment.
- Clones should be created with CREATE2 to ensure they can be consistent across chains.
- Clones should use `keccak256(name)` as the salt, so that if an identity changes their name, they get a new anchor address.
- The logic in Registry.sol needs to change so that users remain owners of identities, even after they change the name.