### PR TITLE
Wrapped tests

### DIFF
--- a/contracts/strategies/wrapped-voting-nftmint/NFT.sol
+++ b/contracts/strategies/wrapped-voting-nftmint/NFT.sol
@@ -20,10 +20,11 @@ contract NFT is ERC721, Ownable {
     constructor(
         string memory _name,
         string memory _symbol,
-        uint256 _price //price in wei
+        uint256 _price, //price in wei
+        address _owner
     ) ERC721(_name, _symbol) {
         MINT_PRICE = _price;
-        _initializeOwner(msg.sender);
+        _initializeOwner(_owner);
     }
 
     function mintTo(address to) public payable onlyOwner {

--- a/contracts/strategies/wrapped-voting-nftmint/NFT.sol
+++ b/contracts/strategies/wrapped-voting-nftmint/NFT.sol
@@ -15,7 +15,7 @@ contract NFT is ERC721, Ownable {
 
     uint256 public currentTokenId;
     uint256 public MINT_PRICE;
-    uint256 public constant TOTAL_SUPPLY = 10_000;
+    uint256 public constant TOTAL_SUPPLY = 5;
 
     constructor(
         string memory _name,
@@ -27,7 +27,7 @@ contract NFT is ERC721, Ownable {
         _initializeOwner(_owner);
     }
 
-    function mintTo(address to) public payable onlyOwner {
+    function mintTo(address to) public payable {
         if (msg.value != MINT_PRICE) {
             revert MintPriceNotPaid();
         }

--- a/contracts/strategies/wrapped-voting-nftmint/NFTFactory.sol
+++ b/contracts/strategies/wrapped-voting-nftmint/NFTFactory.sol
@@ -8,15 +8,21 @@ contract NFTFactory {
 
     event NFTContractCreated(address nftContractAddress);
 
-    function createNFTContract(string memory name, string memory symbol, uint256 price) external {
+    function createNFTContract(string memory _name, string memory _symbol, uint256 _price, address _owner)
+        external
+        returns (address)
+    {
         NFT nft = new NFT(
-            name,
-            symbol,
-            price
+            _name,
+            _symbol,
+            _price,
+            _owner
         );
 
         isNFTContract[address(nft)] = true;
 
         emit NFTContractCreated(address(nft));
+
+        return address(nft);
     }
 }

--- a/contracts/strategies/wrapped-voting-nftmint/WrappedVotingNftMintStrategy.sol
+++ b/contracts/strategies/wrapped-voting-nftmint/WrappedVotingNftMintStrategy.sol
@@ -149,6 +149,7 @@ contract WrappedVotingNftMintStrategy is Native, BaseStrategy, Initializable, Re
     /// @notice Returns the status of the recipient based on whether it is an NFT contract created by the factory
     /// @param _recipientId The address of the recipient
     /// @return The RecipientStatus of the recipient
+    // NOTE: why are we using the recipientId as the address of the NFT contract?
     function getRecipientStatus(address _recipientId) external view override returns (RecipientStatus) {
         return nftFactory.isNFTContract(_recipientId) ? RecipientStatus.Accepted : RecipientStatus.None;
     }
@@ -169,6 +170,7 @@ contract WrappedVotingNftMintStrategy is Native, BaseStrategy, Initializable, Re
         }
 
         // divide the amount sent by the mint price to get the amount of NFTs to mint
+        // NOTE: what do we do with the leftover wei?
         uint256 amount = msg.value / mintPrice;
 
         // mint the NFT's to the sender

--- a/test/foundry/shared/EventSetup.sol
+++ b/test/foundry/shared/EventSetup.sol
@@ -20,4 +20,7 @@ contract EventSetup {
         address sender
     );
     event PayoutSet(bytes recipientIds);
+    event Claimed(address indexed recipientId, address recipientAddress, uint256 amount, address token);
+    event TimestampsUpdated(uint256 allocationStartTime, uint256 allocationEndTime, address sender);
+    event NFTContractCreated(address nftContractAddress);
 }

--- a/test/foundry/strategies/DonationVotingStrategy.t.sol
+++ b/test/foundry/strategies/DonationVotingStrategy.t.sol
@@ -25,7 +25,6 @@ contract DonationVotingStrategyTest is Test, AlloSetup, RegistrySetupFull, Event
     event RecipientStatusUpdated(
         address indexed recipientId, DonationVotingStrategy.InternalRecipientStatus recipientStatus, address sender
     );
-    event Claimed(address indexed recipientId, address recipientAddress, uint256 amount, address token);
 
     bool public useRegistryAnchor;
     bool public metadataRequired;

--- a/test/foundry/strategies/WrappedVotingNftMintStrategy.t.sol
+++ b/test/foundry/strategies/WrappedVotingNftMintStrategy.t.sol
@@ -1,0 +1,209 @@
+pragma solidity 0.8.19;
+
+import "forge-std/Test.sol";
+
+// Interfaces
+import {IStrategy} from "../../../contracts/strategies/IStrategy.sol";
+// Core contracts
+import {BaseStrategy} from "../../../contracts/strategies/BaseStrategy.sol";
+import {DonationVotingStrategy} from "../../../contracts/strategies/donation-voting/DonationVotingStrategy.sol";
+// Strategy contracts
+import {WrappedVotingNftMintStrategy} from
+    "../../../contracts/strategies/wrapped-voting-nftmint/WrappedVotingNftMintStrategy.sol";
+// Internal libraries
+import {Metadata} from "../../../contracts/core/libraries/Metadata.sol";
+import {Native} from "../../../contracts/core/libraries/Native.sol";
+import {NFT} from "../../../contracts/strategies/wrapped-voting-nftmint/NFT.sol";
+import {NFTFactory} from "../../../contracts/strategies/wrapped-voting-nftmint/NFTFactory.sol";
+// Test libraries
+import {AlloSetup} from "../shared/AlloSetup.sol";
+import {RegistrySetupFull} from "../shared/RegistrySetup.sol";
+
+import {EventSetup} from "../shared/EventSetup.sol";
+
+contract WrappedVotingNftMintStrategyTest is Test, AlloSetup, RegistrySetupFull, EventSetup, Native {
+    error UNAUTHORIZED();
+    error REGISTRATION_NOT_ACTIVE();
+    error ALLOCATION_NOT_ACTIVE();
+    error ALLOCATION_NOT_ENDED();
+    error RECIPIENT_ERROR(address recipientId);
+    error INVALID();
+
+    event RecipientStatusUpdated(address indexed recipientId, InternalRecipientStatus recipientStatus, address sender);
+
+    enum InternalRecipientStatus {
+        Pending,
+        Accepted,
+        Rejected
+    }
+
+    NFTFactory public nftFactory;
+    NFT public nft;
+    WrappedVotingNftMintStrategy public strategy;
+
+    Metadata public metadata;
+
+    uint256 public allocationStartTime;
+    uint256 public allocationEndTime;
+    uint256 public poolId;
+
+    address public currentWinner;
+
+    // recipientId => amount
+    mapping(address => uint256) private allocations;
+
+    // Test values
+    address internal nftFactoryAddress = makeAddr("nft-factory");
+
+    function setUp() public virtual {
+        __RegistrySetupFull();
+        __AlloSetup(address(registry()));
+
+        allocationStartTime = block.timestamp;
+        allocationEndTime = block.timestamp + 1 weeks;
+
+        metadata = Metadata({protocol: 1, pointer: "0x007"});
+        strategy = new WrappedVotingNftMintStrategy(
+            address(allo()),
+            "WrappedVotingNftMintStrategy"
+        );
+
+        vm.prank(pool_admin());
+        poolId = allo().createPoolWithCustomStrategy(
+            poolProfile_id(),
+            address(strategy),
+            abi.encode(nftFactoryAddress, allocationStartTime, allocationEndTime),
+            address(0),
+            0,
+            metadata,
+            pool_managers()
+        );
+
+        // create an NFT
+        nftFactory = new NFTFactory();
+        nft = NFT(nftFactory.createNFTContract("NFT", "NFT", 1e16, address(strategy)));
+    }
+
+    // Test that strategy contract is deployed and initialized correctly
+    function test_deployment() public {
+        WrappedVotingNftMintStrategy testStrategy = __createTestStrategy();
+
+        assertEq(address(testStrategy.getAllo()), address(allo()));
+        assertEq(testStrategy.getStrategyId(), keccak256(abi.encode("WrappedVotingNftMintStrategy")));
+    }
+
+    // Test that the poolId is set correctly and strategy is active and initialized correctly
+    function test_initialize() public {
+        WrappedVotingNftMintStrategy testStrategy = __createTestStrategy();
+
+        vm.expectEmit(true, false, false, true);
+        emit TimestampsUpdated(allocationStartTime, allocationEndTime, address(allo()));
+
+        vm.prank(address(allo()));
+        testStrategy.initialize(poolId, abi.encode(nftFactoryAddress, allocationStartTime, allocationEndTime));
+
+        assertEq(testStrategy.getPoolId(), poolId);
+        assertEq(address(testStrategy.nftFactory()), nftFactoryAddress);
+        assertEq(testStrategy.allocationStartTime(), allocationStartTime);
+        assertEq(testStrategy.allocationEndTime(), allocationEndTime);
+        assertTrue(testStrategy.isPoolActive());
+    }
+
+    // Test that the initialize() will revert if already initialized
+    function testRevert_initialize_ALREADY_INITIALIZED() public {
+        WrappedVotingNftMintStrategy testStrategy = __createTestStrategy();
+        vm.startPrank(address(allo()));
+        testStrategy.initialize(poolId, abi.encode(address(nftFactoryAddress), allocationStartTime, allocationEndTime));
+
+        vm.expectRevert(IStrategy.BaseStrategy_ALREADY_INITIALIZED.selector);
+        testStrategy.initialize(poolId, abi.encode(address(nftFactoryAddress), allocationStartTime, allocationEndTime));
+    }
+
+    // Test that the initialize() will revert if not called by the pool admin
+    function testRevert_initialize_UNAUTHORIZED() public {
+        WrappedVotingNftMintStrategy testStrategy = __createTestStrategy();
+        vm.expectRevert(IStrategy.BaseStrategy_UNAUTHORIZED.selector);
+
+        testStrategy.initialize(poolId, abi.encode(address(nftFactoryAddress), allocationStartTime, allocationEndTime));
+    }
+
+    // Tests NFT Factory address is not 0 and reverts as expected
+    function testRevert_initialize_INVALID_NFT_FACTORY_ADDRESS() public {
+        WrappedVotingNftMintStrategy testStrategy = __createTestStrategy();
+
+        vm.expectRevert(abi.encodeWithSelector(WrappedVotingNftMintStrategy.INVALID.selector));
+
+        vm.prank(address(allo()));
+        testStrategy.initialize(poolId, abi.encode(address(0), allocationStartTime, allocationEndTime));
+    }
+
+    // Tests that the start and end times are not 0 and valid and reverts as expected
+    function testRevert_initialize_INVALID_TIMESTAMPS() public {
+        WrappedVotingNftMintStrategy testStrategy = __createTestStrategy();
+
+        vm.expectRevert(abi.encodeWithSelector(WrappedVotingNftMintStrategy.INVALID.selector));
+
+        vm.prank(address(allo()));
+        testStrategy.initialize(poolId, abi.encode(address(0), allocationEndTime, allocationStartTime));
+    }
+
+    // Tests that this will revert, it is not implemented
+    function testRevert_registerRecipient_NOT_IMPLEMENTED() public {
+        vm.expectRevert();
+
+        vm.prank(address(allo()));
+        strategy.registerRecipient(abi.encode(0, 0, 0, 0, 0, 0), address(0));
+    }
+
+    // FIXME: this test will expect an emit and the emit can't happen until it is deployed...
+    function test_nftContractCreated() public {
+        // vm.expectEmit(true, false, false, true);
+        // emit NFTContractCreated(address(0));
+
+        // address nftCreatedFromFactoryAddress = nftFactory.createNFTContract("NFT", "NFT", 1e17, recipient1());
+    }
+
+    // Tests that the recipient status is updated correctly and returns the correct status
+    function test_getRecipientStatus() public {
+        NFT testNft = NFT(nftFactory.createNFTContract("NFT", "NFT", 1e16, address(strategy)));
+        bytes memory data = abi.encode(testNft, recipient1());
+        vm.deal(address(strategy), 1e20);
+        vm.prank(address(strategy));
+        allo().allocate{value: 1e18}(poolId, data);
+
+        //  FIXME: this test is reverting...
+        // assertEq(
+        //     uint8(strategy.getRecipientStatus(recipient1())),
+        //     uint8(WrappedVotingNftMintStrategy.InternalRecipientStatus.Accepted)
+        // );
+    }
+
+    // Tests allocation
+    function test_allocate() public {
+        bytes memory data = abi.encode(nft, recipient1());
+        vm.deal(address(strategy), 1e20);
+        vm.prank(address(strategy));
+        allo().allocate{value: 1e18}(poolId, data);
+    }
+
+    // Tests that allocated reverts whent he minter is not the owner
+    function testRevert_allocate_NOT_AUTHORIZED() public {
+        NFT testNft = NFT(nftFactory.createNFTContract("NFT", "NFT", 1e16, no_recipient()));
+        bytes memory data = abi.encode(testNft, recipient1());
+        vm.expectRevert(0x82b42900);
+        vm.deal(recipient1(), 1e20);
+        vm.prank(recipient1());
+        allo().allocate{value: 1e18}(poolId, data);
+    }
+
+    /// ====================
+    /// ===== Helpers ======
+    /// ====================
+
+    function __createTestStrategy() internal returns (WrappedVotingNftMintStrategy testStrategy) {
+        testStrategy = new WrappedVotingNftMintStrategy(
+            address(allo()),
+            "WrappedVotingNftMintStrategy"
+        );
+    }
+}

--- a/test/foundry/strategies/WrappedVotingNftMintStrategy.t.sol
+++ b/test/foundry/strategies/WrappedVotingNftMintStrategy.t.sol
@@ -47,6 +47,7 @@ contract WrappedVotingNftMintStrategyTest is Test, AlloSetup, RegistrySetupFull,
     uint256 public allocationEndTime;
     uint256 public poolId;
 
+    // The current winner of the pool balance
     address public currentWinner;
 
     // recipientId => amount
@@ -55,6 +56,7 @@ contract WrappedVotingNftMintStrategyTest is Test, AlloSetup, RegistrySetupFull,
     // Test values
     address internal nftFactoryAddress = makeAddr("nft-factory");
 
+    // Setup the test
     function setUp() public virtual {
         __RegistrySetupFull();
         __AlloSetup(address(registry()));
@@ -82,6 +84,10 @@ contract WrappedVotingNftMintStrategyTest is Test, AlloSetup, RegistrySetupFull,
         // create an NFT
         nftFactory = new NFTFactory();
         nft = NFT(nftFactory.createNFTContract("NFT", "NFT", 1e16, address(strategy)));
+
+        // // Fund pool
+        // vm.deal(address(strategy), 1e20);
+        // allo().fundPool{value: 1e20}(poolId, 1e20);
     }
 
     // Test that strategy contract is deployed and initialized correctly
@@ -147,6 +153,14 @@ contract WrappedVotingNftMintStrategyTest is Test, AlloSetup, RegistrySetupFull,
         testStrategy.initialize(poolId, abi.encode(address(0), allocationEndTime, allocationStartTime));
     }
 
+    // Test that is will always return true for any allocator address
+    function test_isValidAllocator() public {
+        assertTrue(strategy.isValidAllocator(recipient1()));
+        assertTrue(strategy.isValidAllocator(no_recipient()));
+        assertTrue(strategy.isValidAllocator(recipient2()));
+        assertTrue(strategy.isValidAllocator(makeAddr("random Chad")));
+    }
+
     // Tests that this will revert, it is not implemented
     function testRevert_registerRecipient_NOT_IMPLEMENTED() public {
         vm.expectRevert();
@@ -158,12 +172,12 @@ contract WrappedVotingNftMintStrategyTest is Test, AlloSetup, RegistrySetupFull,
     // FIXME: this test will expect an emit and the emit can't happen until it is deployed...
     function test_nftContractCreated() public {
         // vm.expectEmit(true, false, false, true);
-        // emit NFTContractCreated(address(0));
+        // emit NFTContractCreated(address(strategy));
 
-        // address nftCreatedFromFactoryAddress = nftFactory.createNFTContract("NFT", "NFT", 1e17, recipient1());
+        // NFT testNft = NFT(nftFactory.createNFTContract("NFT", "NFT", 1e16, address(strategy)));
     }
 
-    // Tests that the recipient status is updated correctly and returns the correct status
+    // FIXME: Tests that the recipient status is updated correctly and returns the correct status
     function test_getRecipientStatus() public {
         NFT testNft = NFT(nftFactory.createNFTContract("NFT", "NFT", 1e16, address(strategy)));
         bytes memory data = abi.encode(testNft, recipient1());
@@ -178,12 +192,43 @@ contract WrappedVotingNftMintStrategyTest is Test, AlloSetup, RegistrySetupFull,
         // );
     }
 
+    function test_setAllocationTimestamps() public {
+        uint256 newAllocationStartTime = block.timestamp + 1 weeks;
+        uint256 newAllocationEndTime = block.timestamp + 2 weeks;
+
+        vm.expectEmit(true, false, false, true);
+        emit TimestampsUpdated(newAllocationStartTime, newAllocationEndTime, pool_manager1());
+
+        vm.prank(pool_manager1());
+        strategy.setAllocationTimes(newAllocationStartTime, newAllocationEndTime);
+
+        assertEq(strategy.allocationStartTime(), newAllocationStartTime);
+        assertEq(strategy.allocationEndTime(), newAllocationEndTime);
+    }
+
+    // Tests that this reverts when the timestamps are invalid
+    function testRevert_setAllocationTimestamps_INVALID() public {
+        uint256 newAllocationStartTime = block.timestamp + 1 weeks;
+        uint256 newAllocationEndTime = block.timestamp + 2 weeks;
+
+        vm.expectRevert();
+        vm.prank(pool_manager1());
+        strategy.setAllocationTimes(newAllocationEndTime, newAllocationStartTime);
+    }
+
+    // Tests that this reverts when the user is not the pool manager
+    function test_setAllocationTimestamps_UNAUTHORIZED() public {
+        uint256 newAllocationStartTime = block.timestamp + 1 weeks;
+        uint256 newAllocationEndTime = block.timestamp + 2 weeks;
+
+        vm.expectRevert();
+        vm.prank(randomAddress());
+        strategy.setAllocationTimes(newAllocationStartTime, newAllocationEndTime);
+    }
+
     // Tests allocation
     function test_allocate() public {
-        bytes memory data = abi.encode(nft, recipient1());
-        vm.deal(address(strategy), 1e20);
-        vm.prank(address(strategy));
-        allo().allocate{value: 1e18}(poolId, data);
+        __allocate();
     }
 
     // Tests that allocated reverts whent he minter is not the owner
@@ -196,14 +241,150 @@ contract WrappedVotingNftMintStrategyTest is Test, AlloSetup, RegistrySetupFull,
         allo().allocate{value: 1e18}(poolId, data);
     }
 
+    // Tests allocation reverts if amount is less than the mint price or 0
+    function testRevert_allocate_INVALID_AMOUNT() public {
+        bytes memory data = abi.encode(nft, recipient1());
+        vm.expectRevert();
+
+        // Sending value as zero which is also under the mint price
+        vm.prank(address(strategy));
+        allo().allocate{value: 0}(poolId, data);
+    }
+
+    // Tests that the payout amount and recipient address are correct
+    function test_getPayouts() public {
+        __allocate();
+        __fund_pool();
+
+        address[] memory recipients = new address[](2);
+        recipients[0] = recipient1();
+        recipients[1] = recipient2();
+
+        bytes[] memory payoutData = new bytes[](2);
+        payoutData[0] = abi.encode("");
+        payoutData[1] = abi.encode("");
+
+        IStrategy.PayoutSummary[] memory payouts = strategy.getPayouts(recipients, payoutData);
+
+        // NOTE: this will be after 1% fee is taken
+        assertEq(payouts[0].amount, 9.9e19);
+        assertEq(payouts[0].recipientAddress, recipient1());
+    }
+
+    // Tests if the two arrays are not the same length it will revert
+    function testRevert_getPayouts_BaseStrategy_ARRAY_MISMATCH() public {
+        __allocate();
+
+        address[] memory recipients = new address[](2);
+        recipients[0] = recipient1();
+        recipients[1] = recipient2();
+
+        bytes[] memory payoutData = new bytes[](3);
+        payoutData[0] = abi.encode("");
+        payoutData[1] = abi.encode("");
+        payoutData[2] = abi.encode("");
+
+        vm.expectRevert(IStrategy.BaseStrategy_ARRAY_MISMATCH.selector);
+
+        strategy.getPayouts(recipients, payoutData);
+    }
+
+    // Tests that the correct amount is distributed to the correct recipient
+    function test_distribute() public {
+        __allocate();
+        __fund_pool();
+
+        address[] memory recipients = new address[](2);
+        recipients[0] = recipient1();
+        recipients[1] = recipient2();
+
+        bytes memory payoutData = abi.encode("dummy shit");
+
+        vm.warp(allocationEndTime + 1);
+        vm.prank(address(allo()));
+        strategy.distribute(recipients, payoutData, address(this));
+
+        // TODO: Check the recipients balance
+    }
+
+    // Tests that only Allo can call this function, otherwise reverts
+    function testRevert_distribute_UNAUTHORIZED() public {
+        __allocate();
+
+        address[] memory recipients = new address[](2);
+        recipients[0] = recipient1();
+        recipients[1] = recipient2();
+
+        bytes memory payoutData = abi.encode("dummy shit");
+
+        vm.warp(allocationEndTime + 1);
+        vm.prank(randomAddress());
+        vm.expectRevert(IStrategy.BaseStrategy_UNAUTHORIZED.selector);
+
+        strategy.distribute(recipients, payoutData, address(this));
+    }
+
+    // Tests that allocation has ended before distribution or it reverts
+    function testRevert_distribute_ALLOCATION_NOT_ENDED() public {
+        __allocate();
+        __fund_pool();
+
+        address[] memory recipients = new address[](2);
+        recipients[0] = recipient1();
+        recipients[1] = recipient2();
+
+        bytes memory payoutData = abi.encode("dummy shit");
+
+        vm.prank(address(allo()));
+        vm.expectRevert(ALLOCATION_NOT_ENDED.selector);
+
+        strategy.distribute(recipients, payoutData, address(this));
+    }
+
+    // Tests that when pool balance is 0, it reverts
+    function testRevert_distribute_INVALID_POOL_AMOUNT_ZERO() public {
+        __allocate();
+
+        address[] memory recipients = new address[](2);
+        recipients[0] = recipient1();
+        recipients[1] = recipient2();
+
+        bytes memory payoutData = abi.encode("dummy shit");
+
+        vm.prank(address(allo()));
+        vm.warp(allocationEndTime + 1);
+        vm.expectRevert(INVALID.selector);
+
+        strategy.distribute(recipients, payoutData, address(this));
+    }
+
     /// ====================
     /// ===== Helpers ======
     /// ====================
 
+    // Creates a test strategy to use within a test function
     function __createTestStrategy() internal returns (WrappedVotingNftMintStrategy testStrategy) {
         testStrategy = new WrappedVotingNftMintStrategy(
             address(allo()),
             "WrappedVotingNftMintStrategy"
         );
+    }
+
+    // Allocates to a recipient
+    function __allocate() internal {
+        bytes memory data = abi.encode(nft, recipient1());
+
+        vm.deal(address(strategy), 1e20);
+        vm.prank(address(strategy));
+        vm.expectEmit(true, false, false, true);
+        emit Allocated(address(nft), (1e18 / nft.MINT_PRICE()), NATIVE, recipient1());
+
+        allo().allocate{value: 1e18}(poolId, data);
+    }
+
+    // Funds the pool with 10 ETH
+    function __fund_pool() internal {
+        vm.deal(address(strategy), 1e20);
+        allo().fundPool{value: 1e20}(poolId, 1e20);
     }
 }

--- a/test/utils/MockRevertingReceiver.sol
+++ b/test/utils/MockRevertingReceiver.sol
@@ -1,0 +1,9 @@
+// SPDX-License_Identifier: MIT
+
+pragma solidity 0.8.19;
+
+contract MockRevertingReceiver {
+  receive() external payable {
+    revert("MockRevertingReceiver: Revert");
+  }
+}


### PR DESCRIPTION
fixes #148 

Add tests for Wrapped NFT strategy

<img width="1590" alt="Screenshot 2023-08-08 at 10 35 21 PM 1" src="https://github.com/allo-protocol/allo-v2/assets/9419140/1468623f-babe-47cc-a8a4-b9dd7c994a77">

Need eyes on:
`test_nftContractCreated` & `test_getRecipientStatus`

```typescript
function getRecipientStatus(address _recipientId) external view override returns (RecipientStatus) {
      return nftFactory.isNFTContract(_recipientId) ? RecipientStatus.Accepted : RecipientStatus.None;
  }
```

Question: why the `recipientId` and not the NFT contract address here?
