### PR TITLE
chore: update milestone logic

### DIFF
--- a/contracts/strategies/direct-grants-simple/DirectGrantsSimpleStrategy.sol
+++ b/contracts/strategies/direct-grants-simple/DirectGrantsSimpleStrategy.sol
@@ -243,11 +243,11 @@ contract DirectGrantsSimpleStrategy is BaseStrategy, ReentrancyGuard {
     /// @param _milestoneId Id of the milestone
     function rejectMilestone(address _recipientId, uint256 _milestoneId) external onlyPoolManager(msg.sender) {
         Milestone[] storage recipientMilestones = milestones[_recipientId];
-        Milestone storage milestone = recipientMilestones[_milestoneId];
-
         if (_milestoneId > recipientMilestones.length) {
             revert INVALID_MILESTONE();
         }
+
+        Milestone storage milestone = recipientMilestones[_milestoneId];
 
         if (milestone.milestoneStatus == RecipientStatus.Accepted) {
             revert MILESTONE_ALREADY_ACCEPTED();

--- a/contracts/strategies/direct-grants-simple/DirectGrantsSimpleStrategy.sol
+++ b/contracts/strategies/direct-grants-simple/DirectGrantsSimpleStrategy.sol
@@ -32,7 +32,6 @@ contract DirectGrantsSimpleStrategy is BaseStrategy, ReentrancyGuard {
         Metadata metadata;
         InternalRecipientStatus recipientStatus;
         RecipientStatus milestonesReviewStatus;
-        address creator;
     }
 
     /// @notice Struct to hold milestone details
@@ -180,7 +179,7 @@ contract DirectGrantsSimpleStrategy is BaseStrategy, ReentrancyGuard {
             revert MILESTONES_ALREADY_SET();
         }
 
-        bool isRecipientCreator = recipient.creator == msg.sender;
+        bool isRecipientCreator = (msg.sender == _recipientId) || _isProfileMember(_recipientId, msg.sender);
         bool isPoolManager = allo.isPoolManager(poolId, msg.sender);
         if (!isRecipientCreator && !isPoolManager) {
             revert UNAUTHORIZED();
@@ -327,8 +326,7 @@ contract DirectGrantsSimpleStrategy is BaseStrategy, ReentrancyGuard {
             grantAmount: grantAmount,
             metadata: metadata,
             recipientStatus: InternalRecipientStatus.Pending,
-            milestonesReviewStatus: RecipientStatus.Pending,
-            creator: _sender
+            milestonesReviewStatus: RecipientStatus.Pending
         });
 
         _recipients[recipientId] = recipient;

--- a/contracts/strategies/direct-grants-simple/DirectGrantsSimpleStrategy.sol
+++ b/contracts/strategies/direct-grants-simple/DirectGrantsSimpleStrategy.sol
@@ -170,7 +170,7 @@ contract DirectGrantsSimpleStrategy is BaseStrategy, ReentrancyGuard {
     /// @param _recipientId Id of the recipient
     /// @param _milestones The milestones to be set
     function setMilestones(address _recipientId, Milestone[] memory _milestones) external {
-        Recipient memory recipient = _getRecipient(_recipientId);
+        Recipient storage recipient = _recipients[_recipientId];
 
         if (recipient.recipientStatus != InternalRecipientStatus.Accepted) {
             revert RECIPIENT_NOT_ACCEPTED();
@@ -197,7 +197,7 @@ contract DirectGrantsSimpleStrategy is BaseStrategy, ReentrancyGuard {
     /// @notice Review the set milestones of the recipient
     /// @param _recipientId Id of the recipient
     function reviewSetMilestones(address _recipientId, RecipientStatus _status) external onlyPoolManager(msg.sender) {
-        Recipient memory recipient = _getRecipient(_recipientId);
+        Recipient storage recipient = _recipients[_recipientId];
         if (recipient.milestonesReviewStatus == RecipientStatus.Accepted) {
             revert MILESTONES_ALREADY_SET();
         }

--- a/contracts/strategies/direct-grants-simple/DirectGrantsSimpleStrategy.sol
+++ b/contracts/strategies/direct-grants-simple/DirectGrantsSimpleStrategy.sol
@@ -220,6 +220,11 @@ contract DirectGrantsSimpleStrategy is BaseStrategy, ReentrancyGuard {
             revert UNAUTHORIZED();
         }
 
+        Recipient memory recipient = _recipients[_recipientId];
+        if (recipient.recipientStatus != InternalRecipientStatus.Accepted) {
+            revert RECIPIENT_NOT_ACCEPTED();
+        }
+
         Milestone[] storage recipientMilestones = milestones[_recipientId];
 
         if (_milestoneId > recipientMilestones.length) {

--- a/contracts/strategies/direct-grants-simple/DirectGrantsSimpleStrategy.sol
+++ b/contracts/strategies/direct-grants-simple/DirectGrantsSimpleStrategy.sol
@@ -355,6 +355,8 @@ contract DirectGrantsSimpleStrategy is BaseStrategy, ReentrancyGuard {
 
         Recipient storage recipient = _recipients[recipientId];
 
+        // TODO: should we check if the milestoneReviewStatus is accepted? instead? 
+        // an accepted milestoneReviewStatus means that the milestones are set and they can only be set if recipient is accepted
         if (
             recipient.recipientStatus != InternalRecipientStatus.Accepted // no need to accept twice
                 && recipientStatus == InternalRecipientStatus.Accepted

--- a/test/foundry/strategies/DirectGrantsSimpleStrategy.t.sol
+++ b/test/foundry/strategies/DirectGrantsSimpleStrategy.t.sol
@@ -551,6 +551,17 @@ contract DirectGrantsSimpleStrategyTest is Test, EventSetup, AlloSetup, Registry
         assertEq(uint8(milestones[1].milestoneStatus), uint8(IStrategy.RecipientStatus.Pending));
     }
 
+    function testRever_submitMilestones_RECIPIENT_NOT_ACCEPTED() public {
+        address recipientId = _register_recipient_allocate_reject();
+
+        Metadata memory metadata2 = Metadata(1, "milestone-2");
+
+        vm.expectRevert(DirectGrantsSimpleStrategy.RECIPIENT_NOT_ACCEPTED.selector);
+        vm.startPrank(profile1_member1());
+        strategy.submitMilestone(recipientId, 1, metadata2);
+        vm.stopPrank();
+    }
+
     function testRevert_submitMilestone_UNAUTHORIZED() public {
         address recipientId = _register_recipient_allocate_accept_set_milestones_by_pool_manager();
 

--- a/test/foundry/strategies/DirectGrantsSimpleStrategy.t.sol
+++ b/test/foundry/strategies/DirectGrantsSimpleStrategy.t.sol
@@ -83,7 +83,6 @@ contract DirectGrantsSimpleStrategyTest is Test, EventSetup, AlloSetup, Registry
         assertTrue(recipient.metadata.protocol == 1);
         assertTrue(recipient.recipientStatus == DirectGrantsSimpleStrategy.InternalRecipientStatus.Pending);
         assertTrue(recipient.milestonesReviewStatus == IStrategy.RecipientStatus.Pending);
-        assertEq(recipient.creator, profile1_member1());
         assertTrue(recipient.useRegistryAnchor);
 
         IStrategy.RecipientStatus status = strategy.getRecipientStatus(recipientId);

--- a/test/foundry/strategies/DirectGrantsSimpleStrategy.t.sol
+++ b/test/foundry/strategies/DirectGrantsSimpleStrategy.t.sol
@@ -332,6 +332,7 @@ contract DirectGrantsSimpleStrategyTest is Test, EventSetup, AlloSetup, Registry
         strategy.reviewSetMilestones(recipientId, IStrategy.RecipientStatus.Rejected);
         vm.stopPrank();
 
+        recipient = strategy.getRecipient(profile1_anchor());
         assertEq(uint8(recipient.milestonesReviewStatus), uint8(IStrategy.RecipientStatus.Rejected));
 
         vm.startPrank(pool_manager1());
@@ -341,12 +342,14 @@ contract DirectGrantsSimpleStrategyTest is Test, EventSetup, AlloSetup, Registry
 
         strategy.reviewSetMilestones(recipientId, IStrategy.RecipientStatus.Accepted);
         vm.stopPrank();
+
+        recipient = strategy.getRecipient(profile1_anchor());
         assertEq(uint8(recipient.milestonesReviewStatus), uint8(IStrategy.RecipientStatus.Accepted));
     }
 
     function testRevert_reviewSetMilestones_UNAUTHORIZED() public {
         address recipientId = _register_recipient_allocate_accept_set_milestones_by_recipient();
-        vm.expectRevert(DirectGrantsSimpleStrategy.UNAUTHORIZED.selector);
+        vm.expectRevert(IStrategy.BaseStrategy_UNAUTHORIZED.selector);
 
         vm.startPrank(randomAddress());
         strategy.reviewSetMilestones(recipientId, IStrategy.RecipientStatus.Rejected);

--- a/test/foundry/strategies/DirectGrantsSimpleStrategy.t.sol
+++ b/test/foundry/strategies/DirectGrantsSimpleStrategy.t.sol
@@ -83,7 +83,7 @@ contract DirectGrantsSimpleStrategyTest is Test, EventSetup, AlloSetup, Registry
         assertTrue(recipient.metadata.protocol == 1);
         assertTrue(recipient.recipientStatus == DirectGrantsSimpleStrategy.InternalRecipientStatus.Pending);
         assertTrue(recipient.milestonesReviewStatus == IStrategy.RecipientStatus.Pending);
-        assertTrue(recipient.creator = profile1_member1());
+        assertEq(recipient.creator, profile1_member1());
         assertTrue(recipient.useRegistryAnchor);
 
         IStrategy.RecipientStatus status = strategy.getRecipientStatus(recipientId);
@@ -321,11 +321,12 @@ contract DirectGrantsSimpleStrategyTest is Test, EventSetup, AlloSetup, Registry
 
     function test_reviewSetMilestones() public {
         address recipientId = _register_recipient_allocate_accept_set_milestones_by_recipient();
+        DirectGrantsSimpleStrategy.Recipient memory recipient = strategy.getRecipient(profile1_anchor());
 
         assertEq(uint8(recipient.milestonesReviewStatus), uint8(IStrategy.RecipientStatus.Pending));
 
         vm.expectEmit(false, false, false, true);
-        emit Registered(MilestonesReviewed, IStrategy.RecipientStatus.Rejected);
+        emit MilestonesReviewed(recipientId, IStrategy.RecipientStatus.Rejected);
 
         vm.startPrank(pool_manager1());
         strategy.reviewSetMilestones(recipientId, IStrategy.RecipientStatus.Rejected);
@@ -336,7 +337,7 @@ contract DirectGrantsSimpleStrategyTest is Test, EventSetup, AlloSetup, Registry
         vm.startPrank(pool_manager1());
 
         vm.expectEmit(false, false, false, true);
-        emit Registered(MilestonesReviewed, IStrategy.RecipientStatus.Accepted);
+        emit MilestonesReviewed(recipientId, IStrategy.RecipientStatus.Accepted);
 
         strategy.reviewSetMilestones(recipientId, IStrategy.RecipientStatus.Accepted);
         vm.stopPrank();

--- a/test/foundry/strategies/DirectGrantsSimpleStrategy.t.sol
+++ b/test/foundry/strategies/DirectGrantsSimpleStrategy.t.sol
@@ -433,6 +433,46 @@ contract DirectGrantsSimpleStrategyTest is Test, EventSetup, AlloSetup, Registry
         vm.stopPrank();
     }
 
+    function testRevert_setMilestones_INVALID_MILESTONE_exceed_percentage_doubled() public {
+        address recipientId = _register_recipient_allocate_accept();
+        DirectGrantsSimpleStrategy.Milestone[] memory milestones = new DirectGrantsSimpleStrategy.Milestone[](2);
+
+        milestones[0] = DirectGrantsSimpleStrategy.Milestone({
+            amountPercentage: 0.3e18,
+            metadata: Metadata(1, "milestone-1"),
+            milestoneStatus: IStrategy.RecipientStatus.None
+        });
+
+        milestones[1] = DirectGrantsSimpleStrategy.Milestone({
+            amountPercentage: 0.7e18,
+            metadata: Metadata(1, "milestone-2"),
+            milestoneStatus: IStrategy.RecipientStatus.None
+        });
+
+        vm.startPrank(profile1_member1());
+
+        // set to 100%
+        strategy.setMilestones(recipientId, milestones);
+
+        // todo:
+        // set to 100% again => 200% -> should revert
+        vm.expectRevert(DirectGrantsSimpleStrategy.INVALID_MILESTONE.selector);
+        strategy.setMilestones(recipientId, milestones);
+
+        // check if sum of milestones are equal to 100% (1e18)
+        DirectGrantsSimpleStrategy.Milestone[] memory setMilestones = strategy.getMilestones(recipientId);
+
+        uint256 totalAllocated = 0;
+
+        for (uint256 i = 0; i < setMilestones.length; i++) {
+            totalAllocated += setMilestones[i].amountPercentage;
+        }
+
+        assertEq(totalAllocated, 1e18);
+
+        vm.stopPrank();
+    }
+
     function testRevert_setMilestones_INVALID_MILESTONE_wrong_status() public {
         address recipientId = _register_recipient_allocate_accept();
         DirectGrantsSimpleStrategy.Milestone[] memory milestones = new DirectGrantsSimpleStrategy.Milestone[](2);


### PR DESCRIPTION
### Description

The milestone flow is now updated to 

- recipient registers (no changes here)
- pool manager reviews the recipient (no changes here)
- recipient sets milestones (by invoking setMilestones, which can be invoked multiple times until approved)
- pool manager approves milestones (this will be a new function)
- pool manager can also invoke setMilestones to set milestones and approve them


fixes #214 
fixes #227 