### PR TITLE
Update RFPSimpleStrategy.sol: Enhanced Gas Optimizations and fixed some errors in comments

### DIFF
--- a/contracts/strategies/rfp-simple/RFPSimpleStrategy.sol
+++ b/contracts/strategies/rfp-simple/RFPSimpleStrategy.sol
@@ -16,7 +16,7 @@ contract RFPSimpleStrategy is BaseStrategy, ReentrancyGuard {
     /// ========== Storage =============
     /// ================================
 
-    /// @notice Struct to hold details of an recipient
+    /// @notice Struct to hold details of a recipient
     struct Recipient {
         bool useRegistryAnchor;
         address recipientAddress;
@@ -61,10 +61,10 @@ contract RFPSimpleStrategy is BaseStrategy, ReentrancyGuard {
 
     bool public useRegistryAnchor;
     bool public metadataRequired;
-    uint256 public maxBid;
-    uint256 public upcomingMilestone;
     address public acceptedRecipientId;
     IRegistry private _registry;
+    uint256 public maxBid;
+    uint256 public upcomingMilestone;
 
     address[] private _recipientIds;
     Milestone[] public milestones;
@@ -214,7 +214,7 @@ contract RFPSimpleStrategy is BaseStrategy, ReentrancyGuard {
     /// ============ Internal ==============
     /// ====================================
 
-    /// @notice Submit proposal to RFP pool
+    /// @notice Submit a proposal to RFP pool
     /// @param _data The data to be decoded
     /// @param _sender The sender of the transaction
     function _registerRecipient(bytes memory _data, address _sender)
@@ -330,7 +330,7 @@ contract RFPSimpleStrategy is BaseStrategy, ReentrancyGuard {
         emit Distributed(acceptedRecipientId, recipient.recipientAddress, amount, _sender);
     }
 
-    /// @notice Check if sender is profile owner or member
+    /// @notice Check if the sender is a profile owner or member
     /// @param _anchor Anchor of the profile
     /// @param _sender The sender of the transaction
     function _isProfileMember(address _anchor, address _sender) internal view returns (bool) {
@@ -365,7 +365,7 @@ contract RFPSimpleStrategy is BaseStrategy, ReentrancyGuard {
         return PayoutSummary(recipient.recipientAddress, recipient.proposalBid);
     }
 
-    /// @notice Checks if address is elgible allocator
+    /// @notice Checks if address is eligible allocator
     /// @param _allocator Address of the allocator
     function _isValidAllocator(address _allocator) internal view override returns (bool) {
         return allo.isPoolManager(poolId, _allocator);


### PR DESCRIPTION
Here's the explanation of why I changed the order of those particular state variables:

Usually, EVM stores state variables or storage variables in slots, each slot upto 32 bytes of data and these slots are directly related to gas, i.e more the slots, more the gas gonna be used up!!

So if by anyway we reduced the number of slots, we might optimize the gas a little bit. Take a look at this:

![Screenshot (15)](https://github.com/allo-protocol/allo-v2/assets/88618913/36afcb49-0fc1-4b69-8d81-642d74b70b3e)

Just for some information sake:

- Address takes up 20 bytes
- bool takes up 1 byte
- uint256 takes up 32 bytes and covers up the whole storage

and here's my implementation:

![Screenshot (18)](https://github.com/allo-protocol/allo-v2/assets/88618913/fc030f12-f65b-4fc6-98bf-0c4785385bc0)

Saving 1 extra slot, Hope that makes you clear!!

Plus there's some grammatical fixes in the comments, just some extra stuff done...
