### PR TITLE
chore: handle re-registration

### DIFF
--- a/contracts/strategies/donation-voting-merkle-distribution/DonationVotingMerkleDistributionStrategy.md
+++ b/contracts/strategies/donation-voting-merkle-distribution/DonationVotingMerkleDistributionStrategy.md
@@ -25,7 +25,7 @@ The `DonationVotingMerkleDistributionStrategy` contract presents an advanced fun
     - [Distributing Funds](#distributing-funds)
     - [Checking Distribution Status](#checking-distribution-status)
     - [Checking Distribution Set Status](#checking-distribution-set-status)
-    - [Marking Recipient as Appealed](#marking-recipient-as-appealed)
+    - [Updating Recipient Registration](#updating-recipient-registration)
     - [Checking Recipient Status](#checking-recipient-status)
     - [Getting Recipient Details](#getting-recipient-details)
     - [Getting Payout Summary](#getting-payout-summary)
@@ -207,12 +207,13 @@ In summary, the `DonationVotingMerkleDistributionStrategy` contract introduces a
 * User initiates a distribution set status check request.
 * Checks if the merkle root for distribution has been set.
 
-### Marking Recipient as Appealed
+### Updating Recipient Registration
 
-* Recipient initiates an appeal request.
-* Checks if the recipient's internal status is "Rejected."
-* Updates recipient's internal status to "Appealed."
-* Emits `Appealed` event.
+* Updates recipient metadata via `registerRecipient`
+* Checks if the recipient's internal status is "Rejected.", then update internal status to "Appealed."
+* Checks if the recipient's internal status is "Accepted.", then update internal status to "Pending."
+* Checks if the recipient's internal status is "Pending"/"Appealed", no change in status.
+* Emits `UpdatedRegistration` event.
 
 ### Checking Recipient Status
 

--- a/contracts/strategies/donation-voting-merkle-distribution/DonationVotingMerkleDistributionStrategy.sol
+++ b/contracts/strategies/donation-voting-merkle-distribution/DonationVotingMerkleDistributionStrategy.sol
@@ -658,7 +658,7 @@ contract DonationVotingMerkleDistributionStrategy is BaseStrategy, ReentrancyGua
         uint8 currentStatus = _getUintRecipientStatus(recipientId);
 
         if (currentStatus == uint8(InternalRecipientStatus.None)) {
-            // recipient registring new application
+            // recipient registering new application
             recipientToStatusIndexes[recipientId] = recipientsCounter;
             _setRecipientStatus(recipientId, uint8(InternalRecipientStatus.Pending));
 

--- a/contracts/strategies/wrapped-voting-nftmint/WrappedVotingNftMintStrategy.sol
+++ b/contracts/strategies/wrapped-voting-nftmint/WrappedVotingNftMintStrategy.sol
@@ -34,7 +34,7 @@ contract WrappedVotingNftMintStrategy is Native, BaseStrategy, Initializable, Re
     /// ========== Events =============
     /// ===============================
 
-    event Appealed(address indexed recipientId, bytes data, address sender);
+    event UpdatedRegistration(address indexed recipientId, bytes data, address sender, InternalRecipientStatus status);
     event RecipientStatusUpdated(address indexed recipientId, InternalRecipientStatus recipientStatus, address sender);
     event Claimed(address indexed recipientId, address recipientAddress, uint256 amount, address token);
     event TimestampsUpdated(uint256 allocationStartTime, uint256 allocationEndTime, address sender);

--- a/test/foundry/fuzz/QVSimpleStrategyFuzz.t.sol
+++ b/test/foundry/fuzz/QVSimpleStrategyFuzz.t.sol
@@ -53,7 +53,6 @@ contract QVSimpleStrategyTest is Accounts, StrategySetup, RegistrySetupFull, All
     QVSimpleStrategy public strategy;
     Metadata public poolMetadata;
 
-    event Appealed(address indexed recipientId, bytes data, address sender);
     event Reviewed(address indexed recipientId, QVBaseStrategy.InternalRecipientStatus status, address sender);
     event RoleGranted(address indexed recipientId, address indexed account, bytes32 indexed role);
     event RoleAdminChanged(

--- a/test/foundry/shared/EventSetup.sol
+++ b/test/foundry/shared/EventSetup.sol
@@ -7,7 +7,6 @@ contract EventSetup {
     event Allocated(address indexed recipientId, uint256 amount, address token, address sender);
     event Distributed(address indexed recipientId, address recipientAddress, uint256 amount, address sender);
     event PoolActive(bool active);
-    event Appealed(address indexed recipientId, bytes data, address sender);
     event RoleGranted(address indexed recipientId, address indexed account, bytes32 indexed role);
     event RoleAdminChanged(
         bytes32 indexed newAdminRole, address indexed recipientId, address indexed previousAdminRole

--- a/test/foundry/strategies/DonationVotingMerkleDistributionStrategy.t.sol
+++ b/test/foundry/strategies/DonationVotingMerkleDistributionStrategy.t.sol
@@ -26,6 +26,7 @@ contract DonationVotingMerkleDistributionStrategyTest is Test, AlloSetup, Regist
     event ProfileCreated(
         bytes32 profileId, uint256 nonce, string name, Metadata metadata, address indexed owner, address indexed anchor
     );
+    event UpdatedRegistration(address indexed recipientId, bytes data, address sender, uint8 status);
 
     bool public useRegistryAnchor;
     bool public metadataRequired;
@@ -296,7 +297,7 @@ contract DonationVotingMerkleDistributionStrategyTest is Test, AlloSetup, Regist
         bytes memory data = __generateRecipientWithId(profile1_anchor());
 
         vm.expectEmit(false, false, false, true);
-        emit Appealed(profile1_anchor(), data, profile1_member1());
+        emit UpdatedRegistration(profile1_anchor(), data, profile1_member1(), 4);
 
         vm.prank(address(allo()));
         strategy.registerRecipient(data, profile1_member1());

--- a/test/foundry/strategies/DonationVotingStrategy.t.sol
+++ b/test/foundry/strategies/DonationVotingStrategy.t.sol
@@ -22,6 +22,9 @@ contract DonationVotingStrategyTest is Test, AlloSetup, RegistrySetupFull, Event
     /// ========== Events =============
     /// ===============================
 
+    event UpdatedRegistration(
+        address indexed recipientId, bytes data, address sender, DonationVotingStrategy.InternalRecipientStatus status
+    );
     event RecipientStatusUpdated(
         address indexed recipientId, DonationVotingStrategy.InternalRecipientStatus recipientStatus, address sender
     );
@@ -644,7 +647,7 @@ contract DonationVotingStrategyTest is Test, AlloSetup, RegistrySetupFull, Event
         // appeal
         bytes memory data = __generateRecipientWithoutId();
         vm.expectEmit(true, false, false, true);
-        emit Appealed(recipientId, data, sender);
+        emit UpdatedRegistration(recipientId, data, sender, DonationVotingStrategy.InternalRecipientStatus.Appealed);
 
         vm.prank(address(allo()));
         strategy.registerRecipient(data, sender);


### PR DESCRIPTION
### Updating Recipient Registration

* Updates recipient metadata via `registerRecipient`
* Checks if the recipient's internal status is "Rejected.", then update internal status to "Appealed."
* Checks if the recipient's internal status is "Accepted.", then update internal status to "Pending."
* Checks if the recipient's internal status is "Pending"/"Appealed", no change in status.
* Emits `UpdatedRegistration` event.

fixes #246