### PR TITLE
Update Allo.sol: Optimized code

### DIFF
--- a/contracts/core/Allo.sol
+++ b/contracts/core/Allo.sol
@@ -331,7 +331,7 @@ contract Allo is IAllo, Native, Transfer, Initializable, Ownable, AccessControl,
         }
 
         // Loop through the '_poolIds' & '_data' and call the 'strategy.registerRecipient()' function
-        for (uint256 i = 0; i < poolIdLength;) {
+        for (uint256 i; i < poolIdLength;) {
             recipientIds[i] = pools[_poolIds[i]].strategy.registerRecipient(_data[i], msg.sender);
             unchecked {
                 i++;
@@ -380,7 +380,7 @@ contract Allo is IAllo, Native, Transfer, Initializable, Ownable, AccessControl,
         }
 
         // Loop through the _poolIds & _datas and call the internal _allocate() function
-        for (uint256 i = 0; i < numPools;) {
+        for (uint256 i; i < numPools;) {
             _allocate(_poolIds[i], _datas[i]);
             unchecked {
                 i++;
@@ -462,7 +462,7 @@ contract Allo is IAllo, Native, Transfer, Initializable, Ownable, AccessControl,
 
         // grant pool managers roles
         uint256 managersLength = _managers.length;
-        for (uint256 i = 0; i < managersLength;) {
+        for (uint256 i; i < managersLength;) {
             address manager = _managers[i];
             if (manager == address(0)) {
                 revert ZERO_ADDRESS();
@@ -507,7 +507,7 @@ contract Allo is IAllo, Native, Transfer, Initializable, Ownable, AccessControl,
     /// @param _poolId The 'poolId' for the pool you are funding
     /// @param _strategy The address of the strategy
     function _fundPool(uint256 _amount, uint256 _poolId, IStrategy _strategy) internal {
-        uint256 feeAmount = 0;
+        uint256 feeAmount;
         uint256 amountAfterFee = _amount;
 
         Pool storage pool = pools[_poolId];


### PR DESCRIPTION
The changes I made are:

`uint256 i = 0;` -> `uint256 i;`

Why to waste gas for just initializing any variable to 0 even after we know that default value of all `uint` and `int` is 0..

There's one more thing I would love to point out, see one of the code snippets from this file:
```
for (uint256 i = 0; i < numPools;) {
     _allocate(_poolIds[i], _datas[i]);
     unchecked {
        i++;
     }
}
```
Must say, that `unchecked` part is really worth of appreciation and the idea behind it. But what if we make `i++` -> `++i`.
if that `i` won't be used anywhere after this loop, it be safe to use `++i` and will save even more gas. Even I first thought that what will even happen after making this kind of change, but after running a demo code in remix...it was effective.
I haven't made this change yet, that's why pointed it out here cuz logically change in `i++` to `++i` can bring some undesired working of our contract, just you need to look them out and it's worth changing to `++i` if it doesn't make any faulty change. Just let me know