### PR TITLE
Remove check on register recipient

### DIFF
--- a/contracts/strategies/_poc/qv-impact-stream/QVImpactStreamStrategy.sol
+++ b/contracts/strategies/_poc/qv-impact-stream/QVImpactStreamStrategy.sol
@@ -431,8 +431,8 @@ contract QVImpactStreamStrategy is BaseStrategy, Multicall {
         // Check if the registry anchor is valid so we know whether to use it or not
         isUsingRegistryAnchor = useRegistryAnchor || registryAnchor != address(0);
 
-        // Ternerary to set the recipient id based on whether or not we are using the 'registryAnchor' or '_sender'
-        recipientId = isUsingRegistryAnchor ? registryAnchor : _sender;
+        // Ternerary to set the recipient id based on whether or not we are using the 'registryAnchor' or 'recipientAddress'
+        recipientId = isUsingRegistryAnchor ? registryAnchor : recipientAddress;
 
         // Check if the metadata is required and if it is, check if it is valid, otherwise revert
         if (metadataRequired && (bytes(metadata.pointer).length == 0 || metadata.protocol == 0)) {

--- a/contracts/strategies/_poc/qv-impact-stream/QVImpactStreamStrategy.sol
+++ b/contracts/strategies/_poc/qv-impact-stream/QVImpactStreamStrategy.sol
@@ -434,9 +434,6 @@ contract QVImpactStreamStrategy is BaseStrategy, Multicall {
         // Ternerary to set the recipient id based on whether or not we are using the 'registryAnchor' or '_sender'
         recipientId = isUsingRegistryAnchor ? registryAnchor : _sender;
 
-        // Checks if the '_sender' is a member of the profile 'anchor' being used and reverts if not
-        // if (isUsingRegistryAnchor && !_isProfileMember(recipientId, recipientAddress)) revert UNAUTHORIZED();
-
         // Check if the metadata is required and if it is, check if it is valid, otherwise revert
         if (metadataRequired && (bytes(metadata.pointer).length == 0 || metadata.protocol == 0)) {
             revert INVALID_METADATA();

--- a/contracts/strategies/_poc/qv-impact-stream/QVImpactStreamStrategy.sol
+++ b/contracts/strategies/_poc/qv-impact-stream/QVImpactStreamStrategy.sol
@@ -435,7 +435,7 @@ contract QVImpactStreamStrategy is BaseStrategy, Multicall {
         recipientId = isUsingRegistryAnchor ? registryAnchor : _sender;
 
         // Checks if the '_sender' is a member of the profile 'anchor' being used and reverts if not
-        if (isUsingRegistryAnchor && !_isProfileMember(recipientId, recipientAddress)) revert UNAUTHORIZED();
+        // if (isUsingRegistryAnchor && !_isProfileMember(recipientId, recipientAddress)) revert UNAUTHORIZED();
 
         // Check if the metadata is required and if it is, check if it is valid, otherwise revert
         if (metadataRequired && (bytes(metadata.pointer).length == 0 || metadata.protocol == 0)) {

--- a/contracts/strategies/_poc/qv-impact-stream/QVImpactStreamStrategy.sol
+++ b/contracts/strategies/_poc/qv-impact-stream/QVImpactStreamStrategy.sol
@@ -542,6 +542,9 @@ contract QVImpactStreamStrategy is BaseStrategy, Multicall {
         return allocators[_allocator].votesCastToRecipient[_recipientId];
     }
 
+    /// @notice Get the total votes received for a recipient
+    /// @param _recipientId ID of the recipient
+    /// @return The total votes received by the recipient
     function getTotalVotesForRecipient(address _recipientId) external view returns (uint256) {
         return recipients[_recipientId].totalVotesReceived;
     }

--- a/contracts/strategies/_poc/qv-impact-stream/QVImpactStreamStrategy.sol
+++ b/contracts/strategies/_poc/qv-impact-stream/QVImpactStreamStrategy.sol
@@ -542,6 +542,10 @@ contract QVImpactStreamStrategy is BaseStrategy, Multicall {
         return allocators[_allocator].votesCastToRecipient[_recipientId];
     }
 
+    function getTotalVotesForRecipient(address _recipientId) external view returns (uint256) {
+        return recipients[_recipientId].totalVotesReceived;
+    }
+
     /// @notice Get recipient status
     /// @param _recipientId Id of the recipient
     function _getRecipientStatus(address _recipientId) internal view virtual override returns (Status) {

--- a/test/foundry/strategies/QVImpactStreamStrategyTest.t.sol
+++ b/test/foundry/strategies/QVImpactStreamStrategyTest.t.sol
@@ -215,7 +215,7 @@ contract QVImpactStreamStrategyTest is Test, AlloSetup, RegistrySetupFull, Strat
 
         vm.warp(allocationStartTime + 10);
 
-        vm.expectRevert(abi.encodeWithSelector(RECIPIENT_ERROR.selector, pool_manager1()));
+        vm.expectRevert(abi.encodeWithSelector(RECIPIENT_ERROR.selector, address(0)));
         allo().registerRecipient(
             newPoolId, _createRecipientData(address(0), address(0), 1e18, _createMetadata("Recipient-Metadata"))
         );

--- a/test/foundry/strategies/QVImpactStreamStrategyTest.t.sol
+++ b/test/foundry/strategies/QVImpactStreamStrategyTest.t.sol
@@ -186,13 +186,13 @@ contract QVImpactStreamStrategyTest is Test, AlloSetup, RegistrySetupFull, Strat
         assertEq(recipient.metadata.pointer, "Recipient-Metadata");
     }
 
-    function testRevert_registerRecipient_RECIPIENT_ERROR_no_ProfileId() public virtual {
-        vm.prank(pool_manager1());
-        vm.expectRevert(UNAUTHORIZED.selector);
-        allo().registerRecipient(
-            poolId, _createRecipientData(address(123), profile1_member1(), 1e18, _createMetadata("Recipient-Metadata"))
-        );
-    }
+    // function testRevert_registerRecipient_RECIPIENT_ERROR_no_ProfileId() public virtual {
+    //     vm.prank(pool_manager1());
+    //     vm.expectRevert(UNAUTHORIZED.selector);
+    //     allo().registerRecipient(
+    //         poolId, _createRecipientData(address(123), profile1_member1(), 1e18, _createMetadata("Recipient-Metadata"))
+    //     );
+    // }
 
     function testRevert_registerRecipient_RECIPIENT_ERROR_no_recipientAddress() public virtual {
         QVImpactStreamStrategy newStrategy = new QVImpactStreamStrategy(

--- a/test/foundry/strategies/QVImpactStreamStrategyTest.t.sol
+++ b/test/foundry/strategies/QVImpactStreamStrategyTest.t.sol
@@ -186,14 +186,6 @@ contract QVImpactStreamStrategyTest is Test, AlloSetup, RegistrySetupFull, Strat
         assertEq(recipient.metadata.pointer, "Recipient-Metadata");
     }
 
-    // function testRevert_registerRecipient_RECIPIENT_ERROR_no_ProfileId() public virtual {
-    //     vm.prank(pool_manager1());
-    //     vm.expectRevert(UNAUTHORIZED.selector);
-    //     allo().registerRecipient(
-    //         poolId, _createRecipientData(address(123), profile1_member1(), 1e18, _createMetadata("Recipient-Metadata"))
-    //     );
-    // }
-
     function testRevert_registerRecipient_RECIPIENT_ERROR_no_recipientAddress() public virtual {
         QVImpactStreamStrategy newStrategy = new QVImpactStreamStrategy(
           address(allo()),


### PR DESCRIPTION
Removing this check for Impact Stream Strategy -->

```solidity
[438] if (isUsingRegistryAnchor && !_isProfileMember(recipientId, recipientAddress)) revert UNAUTHORIZED();
```

@0xKurt and I deployed this new version to run the scripts from on Goerli.

cc: @0xKurt @thelostone-mc 