### PR TITLE
Typo Accounts.sol comment

### DIFF
--- a/test/foundry/shared/Accounts.sol
+++ b/test/foundry/shared/Accounts.sol
@@ -5,7 +5,7 @@ import "forge-std/StdCheats.sol";
 
 contract Accounts is StdCheats {
     // //////////////////////
-    // Protocol adresses
+    // Protocol addresses
     // //////////////////////
 
     function local() public view virtual returns (address) {


### PR DESCRIPTION
It has a typo, "adresses". Fixed to "addresses".