### PR TITLE
fix units calculation in SQFSuperFluidStrategy

### DIFF
--- a/contracts/strategies/_poc/sqf-superfluid/SQFSuperFluidStrategy.sol
+++ b/contracts/strategies/_poc/sqf-superfluid/SQFSuperFluidStrategy.sol
@@ -523,18 +523,18 @@ contract SQFSuperFluidStrategy is BaseStrategy, ReentrancyGuard {
 
         if (_previousFlowrate == 0) {
             // created a new flow
-            uint256 scaledFlowRate = _newFlowRate / 1e6;
+            uint256 scaledFlowRate = _newFlowRate / 1e8;
 
             recipientTotalUnits = (recipientTotalUnits.sqrt() + scaledFlowRate.sqrt()) ** 2;
         } else if (_newFlowRate == 0) {
             // canceled a flow
-            uint256 scaledFlowRate = _previousFlowrate / 1e6;
+            uint256 scaledFlowRate = _previousFlowrate / 1e8;
 
             recipientTotalUnits = recipientTotalUnits + scaledFlowRate - 2 * uint256(recipientTotalUnits * scaledFlowRate).sqrt();
         } else {
             // updated a flow
-            uint256 scaledNewFlowRate = _newFlowRate / 1e6;
-            uint256 scaledPreviousFlowRate = _previousFlowrate / 1e6;
+            uint256 scaledNewFlowRate = _newFlowRate / 1e8;
+            uint256 scaledPreviousFlowRate = _previousFlowrate / 1e8;
 
             recipientTotalUnits = (recipientTotalUnits.sqrt() + scaledNewFlowRate.sqrt() - scaledPreviousFlowRate.sqrt()) ** 2;
         }

--- a/contracts/strategies/_poc/sqf-superfluid/SQFSuperFluidStrategy.sol
+++ b/contracts/strategies/_poc/sqf-superfluid/SQFSuperFluidStrategy.sol
@@ -523,13 +523,20 @@ contract SQFSuperFluidStrategy is BaseStrategy, ReentrancyGuard {
 
         if (_previousFlowrate == 0) {
             // created a new flow
-            recipientTotalUnits = (recipientTotalUnits.sqrt() + _newFlowRate.sqrt()) ** 2;
+            uint256 scaledFlowRate = _newFlowRate / 1e6;
+
+            recipientTotalUnits = (recipientTotalUnits.sqrt() + scaledFlowRate.sqrt()) ** 2;
         } else if (_newFlowRate == 0) {
             // canceled a flow
-            recipientTotalUnits = (recipientTotalUnits.sqrt() - _previousFlowrate.sqrt()) ** 2;
+            uint256 scaledFlowRate = _previousFlowrate / 1e6;
+
+            recipientTotalUnits = recipientTotalUnits + scaledFlowRate - 2 * uint256(recipientTotalUnits * scaledFlowRate).sqrt();
         } else {
             // updated a flow
-            recipientTotalUnits = (recipientTotalUnits.sqrt() + _newFlowRate.sqrt() - _previousFlowrate.sqrt()) ** 2;
+            uint256 scaledNewFlowRate = _newFlowRate / 1e6;
+            uint256 scaledPreviousFlowRate = _previousFlowrate / 1e6;
+
+            recipientTotalUnits = (recipientTotalUnits.sqrt() + scaledNewFlowRate.sqrt() - scaledPreviousFlowRate.sqrt()) ** 2;
         }
 
         recipientTotalUnits /= 1000;

--- a/contracts/strategies/_poc/sqf-superfluid/SQFSuperFluidStrategy.sol
+++ b/contracts/strategies/_poc/sqf-superfluid/SQFSuperFluidStrategy.sol
@@ -524,7 +524,7 @@ contract SQFSuperFluidStrategy is BaseStrategy, ReentrancyGuard {
         if (_previousFlowRate == 0) {
             // created a new flow
             uint256 scaledFlowRate = _newFlowRate / 1e6;
-            
+
             if (scaledFlowRate > 0) {
                 recipientTotalUnits = (recipientTotalUnits.sqrt() + scaledFlowRate.sqrt()) ** 2;
             }
@@ -533,7 +533,8 @@ contract SQFSuperFluidStrategy is BaseStrategy, ReentrancyGuard {
             uint256 scaledFlowRate = _previousFlowRate / 1e6;
 
             if (scaledFlowRate > 0) {
-                recipientTotalUnits = recipientTotalUnits + scaledFlowRate - 2 * uint256(recipientTotalUnits * scaledFlowRate).sqrt();
+                recipientTotalUnits =
+                    recipientTotalUnits + scaledFlowRate - 2 * uint256(recipientTotalUnits * scaledFlowRate).sqrt();
             }
         } else {
             // updated a flow
@@ -542,10 +543,11 @@ contract SQFSuperFluidStrategy is BaseStrategy, ReentrancyGuard {
 
             if (scaledNewFlowRate != scaledPreviousFlowRate) {
                 if (scaledNewFlowRate > 0) {
-                    recipientTotalUnits = (recipientTotalUnits.sqrt() + scaledNewFlowRate.sqrt() - scaledPreviousFlowRate.sqrt()) ** 2;
-                } else if (scaledPreviousFlowRate > 0) {
                     recipientTotalUnits =
-                        recipientTotalUnits + scaledPreviousFlowRate - 2 * uint256(recipientTotalUnits * scaledPreviousFlowRate).sqrt();
+                        (recipientTotalUnits.sqrt() + scaledNewFlowRate.sqrt() - scaledPreviousFlowRate.sqrt()) ** 2;
+                } else if (scaledPreviousFlowRate > 0) {
+                    recipientTotalUnits = recipientTotalUnits + scaledPreviousFlowRate
+                        - 2 * uint256(recipientTotalUnits * scaledPreviousFlowRate).sqrt();
                 }
             }
         }

--- a/test/foundry/strategies/SQFSuperFluidStrategy.t.sol
+++ b/test/foundry/strategies/SQFSuperFluidStrategy.t.sol
@@ -574,10 +574,10 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
             )
         );
 
-        assertEq(_strategy.totalUnitsByRecipient(recipientId1), 13);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId1), 14);
         assertEq(_strategy.recipientFlowRate(recipientId1), 761035007610);
 
-        assertEq(_strategy.totalUnitsByRecipient(recipientId2), 18);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId2), 19);
         assertEq(_strategy.recipientFlowRate(recipientId2), 1141552511415);
 
         vm.startPrank(secondAllocator);
@@ -601,10 +601,10 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
 
         vm.stopPrank();
 
-        assertEq(_strategy.totalUnitsByRecipient(recipientId1), 30);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId1), 32);
         assertEq(_strategy.recipientFlowRate(recipientId1), 1141552511415);
 
-        assertEq(_strategy.totalUnitsByRecipient(recipientId2), 48);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId2), 50);
         assertEq(_strategy.recipientFlowRate(recipientId2), 1902587519025);
 
         SuperfluidPool gdaPool = SuperfluidPool(address(_strategy.gdaPool()));
@@ -675,7 +675,7 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
         assertEq(newNetFlowRate, 0);
         assertEq(newFlowRateToRecipient, 0);
         assertEq(isSuperAppJailed, false);
-        assertEq(_strategy.totalUnitsByRecipient(recipientId), 0);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId), 1);
     }
 
     function testRevert_allocate_UNATUTHORIZED() public {

--- a/test/foundry/strategies/SQFSuperFluidStrategy.t.sol
+++ b/test/foundry/strategies/SQFSuperFluidStrategy.t.sol
@@ -20,13 +20,16 @@ import {SuperfluidGovernanceII} from
     "../../../lib/superfluid-protocol-monorepo/packages/ethereum-contracts/contracts/gov/SuperfluidGovernanceII.sol";
 import {
     ISuperfluid,
-    ISuperfluidPool
+    ISuperfluidPool,
+    ISuperApp
 } from
     "../../../lib/superfluid-protocol-monorepo/packages/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol";
 import {ISuperToken} from
     "../../../lib/superfluid-protocol-monorepo/packages/ethereum-contracts/contracts/interfaces/superfluid/ISuperToken.sol";
 import {GeneralDistributionAgreementV1} from
     "../../../lib/superfluid-protocol-monorepo/packages/ethereum-contracts/contracts/agreements/gdav1/GeneralDistributionAgreementV1.sol";
+import {SuperfluidPool} from
+    "../../../lib/superfluid-protocol-monorepo/packages/ethereum-contracts/contracts/agreements/gdav1/SuperfluidPool.sol";
 
 import {MockPassportDecoder} from "test/utils/MockPassportDecoder.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -142,7 +145,7 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
         allo().createPoolWithCustomStrategy(
             poolProfile_id(),
             address(strategy_),
-            __enocdeInitializeParams(),
+            __encodeInitializeParams(),
             address(superFakeDai),
             0,
             Metadata(1, "test"),
@@ -159,7 +162,7 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
         allo().createPoolWithCustomStrategy(
             poolProfile_id(),
             address(strategy_),
-            __enocdeInitializeParams(),
+            __encodeInitializeParams(),
             address(superFakeDai),
             0,
             Metadata(1, "test"),
@@ -500,12 +503,12 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
             poolId,
             abi.encode(
                 recipientId,
-                9000 // super small flowRate
+                380517503805 // 1 per month
             )
         );
 
-        assertEq(_strategy.totalUnitsByRecipient(recipientId), 15);
-        assertEq(_strategy.recipientFlowRate(recipientId), 9000);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId), 418);
+        assertEq(_strategy.recipientFlowRate(recipientId), 380517503805);
     }
 
     function test_allocate_second_time_same_user() public {
@@ -516,12 +519,12 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
             poolId,
             abi.encode(
                 recipientId,
-                16000 // super small flowRate
+                761035007610 // 2 per month
             )
         );
 
-        assertEq(_strategy.totalUnitsByRecipient(recipientId), 23);
-        assertEq(_strategy.recipientFlowRate(recipientId), 16000);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId), 813);
+        assertEq(_strategy.recipientFlowRate(recipientId), 761035007610);
     }
 
     function test_allocate_second_time_different_user() public {
@@ -535,14 +538,14 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
             poolId,
             abi.encode(
                 recipientId,
-                16000 // super small flowRate
+                380517503805 // 1 per month
             )
         );
 
         vm.stopPrank();
 
-        assertEq(_strategy.totalUnitsByRecipient(recipientId), 61);
-        assertEq(_strategy.recipientFlowRate(recipientId), 25000);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId), 1592);
+        assertEq(_strategy.recipientFlowRate(recipientId), 761035007610);
     }
 
     function test_allocate_multiple_recipients() public {
@@ -559,7 +562,7 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
             poolId,
             abi.encode(
                 recipientId1,
-                16000 // super small flowRate
+                761035007610 // 2 per month
             )
         );
 
@@ -567,15 +570,15 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
             poolId,
             abi.encode(
                 recipientId2,
-                25000 // super small flowRate
+                1141552511415 // 3 per month
             )
         );
 
-        assertEq(_strategy.totalUnitsByRecipient(recipientId1), 24);
-        assertEq(_strategy.recipientFlowRate(recipientId1), 16000);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId1), 815);
+        assertEq(_strategy.recipientFlowRate(recipientId1), 761035007610);
 
-        assertEq(_strategy.totalUnitsByRecipient(recipientId2), 35);
-        assertEq(_strategy.recipientFlowRate(recipientId2), 25000);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId2), 1207);
+        assertEq(_strategy.recipientFlowRate(recipientId2), 1141552511415);
 
         vm.startPrank(secondAllocator);
         superFakeDai.increaseFlowRateAllowanceWithPermissions(address(_strategy), 7, type(int96).max);
@@ -584,7 +587,7 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
             poolId,
             abi.encode(
                 recipientId1,
-                9000 // super small flowRate
+                380517503805 // 1 per month
             )
         );
 
@@ -592,17 +595,87 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
             poolId,
             abi.encode(
                 recipientId2,
-                36000 // super small flowRate
+                761035007610 // 2 per month
             )
         );
 
         vm.stopPrank();
 
-        assertEq(_strategy.totalUnitsByRecipient(recipientId1), 61);
-        assertEq(_strategy.recipientFlowRate(recipientId1), 25000);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId1), 2304);
+        assertEq(_strategy.recipientFlowRate(recipientId1), 1141552511415);
 
-        assertEq(_strategy.totalUnitsByRecipient(recipientId2), 141);
-        assertEq(_strategy.recipientFlowRate(recipientId2), 61000);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId2), 3880);
+        assertEq(_strategy.recipientFlowRate(recipientId2), 1902587519025);
+
+        SuperfluidPool gdaPool = SuperfluidPool(address(_strategy.gdaPool()));
+        int96 netFlowGDA = superFakeDai.getNetFlowRate(address(gdaPool));
+        uint128 totalUnits = gdaPool.getTotalUnits();
+
+        assertTrue(uint96(netFlowGDA) > totalUnits);
+    }
+
+    function test_deleteFlow() public {
+        test_allocate_second_time_different_user();
+
+        vm.warp(block.timestamp + 100);
+
+        address recipientId = profile1_anchor();
+        address recipient = _strategy.getRecipient(recipientId).recipientAddress;
+        address superApp = address(_strategy.getSuperApp(recipientId));
+
+        superFakeDai.deleteFlow(address(this), superApp);
+
+        int96 newNetFlowRate = superFakeDai.getCFANetFlowRate(superApp);
+        int96 newFlowRateToRecipient = superFakeDai.getFlowRate(superApp, recipient);
+        bool isSuperAppJailed = ISuperfluid(superfluidHost).isAppJailed(ISuperApp(superApp));
+
+        assertEq(newNetFlowRate, 0);
+        assertEq(newFlowRateToRecipient, 380517503805);
+        assertEq(isSuperAppJailed, false);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId), 415);
+    }
+
+    function test_deleteFlow_multiple_times() public {
+        test_allocate();
+
+        vm.warp(block.timestamp + 100);
+
+        address recipientId = profile1_anchor();
+        address recipient = _strategy.getRecipient(recipientId).recipientAddress;
+        address superApp = address(_strategy.getSuperApp(recipientId));
+
+        superFakeDai.deleteFlow(address(this), superApp);
+
+        vm.warp(block.timestamp + 100);
+
+        int96 newNetFlowRate = superFakeDai.getCFANetFlowRate(superApp);
+        int96 newFlowRateToRecipient = superFakeDai.getFlowRate(superApp, recipient);
+        bool isSuperAppJailed = ISuperfluid(superfluidHost).isAppJailed(ISuperApp(superApp));
+
+        assertEq(newNetFlowRate, 0);
+        assertEq(newFlowRateToRecipient, 0);
+        assertEq(isSuperAppJailed, false);
+
+        allo().allocate(
+            poolId,
+            abi.encode(
+                recipientId,
+                380517503805 // 1 per month
+            )
+        );
+
+        vm.warp(block.timestamp + 100);
+
+        superFakeDai.deleteFlow(address(this), superApp);
+
+        newNetFlowRate = superFakeDai.getCFANetFlowRate(superApp);
+        newFlowRateToRecipient = superFakeDai.getFlowRate(superApp, recipient);
+        isSuperAppJailed = ISuperfluid(superfluidHost).isAppJailed(ISuperApp(superApp));
+
+        assertEq(newNetFlowRate, 0);
+        assertEq(newFlowRateToRecipient, 0);
+        assertEq(isSuperAppJailed, false);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId), 0);
     }
 
     function testRevert_allocate_UNATUTHORIZED() public {
@@ -701,7 +774,7 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
         return new SQFSuperFluidStrategy(address(allo()), "SQFSuperFluidStrategyv1");
     }
 
-    function __enocdeInitializeParams() internal view returns (bytes memory) {
+    function __encodeInitializeParams() internal view returns (bytes memory) {
         return abi.encode(
             useRegistryAnchor,
             metadataRequired,
@@ -722,7 +795,7 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
         _poolId = allo().createPoolWithCustomStrategy(
             poolProfile_id(),
             strategy,
-            __enocdeInitializeParams(),
+            __encodeInitializeParams(),
             address(superFakeDai),
             0,
             Metadata(1, "test"),

--- a/test/foundry/strategies/SQFSuperFluidStrategy.t.sol
+++ b/test/foundry/strategies/SQFSuperFluidStrategy.t.sol
@@ -507,7 +507,7 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
             )
         );
 
-        assertEq(_strategy.totalUnitsByRecipient(recipientId), 418);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId), 8);
         assertEq(_strategy.recipientFlowRate(recipientId), 380517503805);
     }
 
@@ -523,7 +523,7 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
             )
         );
 
-        assertEq(_strategy.totalUnitsByRecipient(recipientId), 813);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId), 13);
         assertEq(_strategy.recipientFlowRate(recipientId), 761035007610);
     }
 
@@ -544,7 +544,7 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
 
         vm.stopPrank();
 
-        assertEq(_strategy.totalUnitsByRecipient(recipientId), 1592);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId), 22);
         assertEq(_strategy.recipientFlowRate(recipientId), 761035007610);
     }
 
@@ -574,10 +574,10 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
             )
         );
 
-        assertEq(_strategy.totalUnitsByRecipient(recipientId1), 815);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId1), 13);
         assertEq(_strategy.recipientFlowRate(recipientId1), 761035007610);
 
-        assertEq(_strategy.totalUnitsByRecipient(recipientId2), 1207);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId2), 18);
         assertEq(_strategy.recipientFlowRate(recipientId2), 1141552511415);
 
         vm.startPrank(secondAllocator);
@@ -601,10 +601,10 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
 
         vm.stopPrank();
 
-        assertEq(_strategy.totalUnitsByRecipient(recipientId1), 2304);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId1), 30);
         assertEq(_strategy.recipientFlowRate(recipientId1), 1141552511415);
 
-        assertEq(_strategy.totalUnitsByRecipient(recipientId2), 3880);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId2), 48);
         assertEq(_strategy.recipientFlowRate(recipientId2), 1902587519025);
 
         SuperfluidPool gdaPool = SuperfluidPool(address(_strategy.gdaPool()));
@@ -632,7 +632,7 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
         assertEq(newNetFlowRate, 0);
         assertEq(newFlowRateToRecipient, 380517503805);
         assertEq(isSuperAppJailed, false);
-        assertEq(_strategy.totalUnitsByRecipient(recipientId), 415);
+        assertEq(_strategy.totalUnitsByRecipient(recipientId), 7);
     }
 
     function test_deleteFlow_multiple_times() public {


### PR DESCRIPTION
The total amount of units in the GDA pool needs to be lower than the flow rate being distributed for the matching pool to send funds to the recipients.
Because in the calculation the amount of units in the GDA pool grows with the allocation flow rate they can easily reach that limit.

An underflow in `adjustWeightings()` happens when the only allocator closes the stream two times, because this happens in the SuperApp termination callback the SuperApp gets jailed by the Superfluid Host contract.

This fixes the issues by:
- Scaling down the flow rate in `adjustWeightings()` for units calculation purpose to make sure the units are order of magnitudes lower than the distribution flow rate for pools and donations of realistic sizes.
- Using a formula that guarantees a positive number for the subtraction in the branch taken during flow deletion callback.