### PR TITLE
SQF: Emergency Functions, Super App factory

### DIFF
--- a/contracts/strategies/_poc/sqf-superfluid/RecipientSuperApp.sol
+++ b/contracts/strategies/_poc/sqf-superfluid/RecipientSuperApp.sol
@@ -92,6 +92,11 @@ contract RecipientSuperApp is ISuperApp {
         IERC20(token).transfer(msg.sender, IERC20(token).balanceOf(address(this)));
     }
 
+    /// @notice Close incoming streams in an emergency
+    function closeIncomingStream(address from) external onlyRecipient {
+        acceptedToken.deleteFlow(from, address(this));
+    }
+
     /// @dev Accepts all super tokens
     function isAcceptedSuperToken(ISuperToken _superToken) public view virtual returns (bool) {
         return address(_superToken) == address(acceptedToken);

--- a/contracts/strategies/_poc/sqf-superfluid/RecipientSuperApp.sol
+++ b/contracts/strategies/_poc/sqf-superfluid/RecipientSuperApp.sol
@@ -14,6 +14,7 @@ import {IInstantDistributionAgreementV1} from
     "../../../../lib/superfluid-protocol-monorepo/packages/ethereum-contracts/contracts/interfaces/agreements/IInstantDistributionAgreementV1.sol";
 
 import {SQFSuperFluidStrategy} from "./SQFSuperFluidStrategy.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract RecipientSuperApp is ISuperApp {
     error UNAUTHORIZED();
@@ -41,6 +42,11 @@ contract RecipientSuperApp is ISuperApp {
     address public recipient;
     SQFSuperFluidStrategy public immutable strategy;
     ISuperToken public immutable acceptedToken;
+
+    modifier onlyRecipient() {
+        _checkOnlyRecipient();
+        _;
+    }
 
     constructor(
         address _recipient,
@@ -81,6 +87,11 @@ contract RecipientSuperApp is ISuperApp {
         recipient = _recipient;
     }
 
+    /// @notice Withdraw ERC20 funds in an emergency
+    function emergencyWithdraw(address token) external onlyRecipient {
+        IERC20(token).transfer(msg.sender, IERC20(token).balanceOf(address(this)));
+    }
+
     /// @dev Accepts all super tokens
     function isAcceptedSuperToken(ISuperToken _superToken) public view virtual returns (bool) {
         return address(_superToken) == address(acceptedToken);
@@ -109,6 +120,12 @@ contract RecipientSuperApp is ISuperApp {
     function _checkHookParam(ISuperToken _superToken) internal view {
         if (msg.sender != address(HOST)) revert UnauthorizedHost();
         if (!isAcceptedSuperToken(_superToken)) revert NotAcceptedSuperToken();
+    }
+
+    function _checkOnlyRecipient() internal view virtual {
+        if (msg.sender != recipient) {
+            revert UNAUTHORIZED();
+        }
     }
 
     // https://Ihub.com/superfluid-finance/super-examples/blob/main/projects/tradeable-cashflow/contracts/RedirectAll.sol#L163

--- a/contracts/strategies/_poc/sqf-superfluid/RecipientSuperAppFactory.sol
+++ b/contracts/strategies/_poc/sqf-superfluid/RecipientSuperAppFactory.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {ISuperToken} from
+    "../../../../lib/superfluid-protocol-monorepo/packages/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol";
+import "./RecipientSuperApp.sol";
+
+contract RecipientSuperAppFactory {
+    function createRecipientSuperApp(
+        address _recipient,
+        address _strategy,
+        address _host,
+        ISuperToken _acceptedToken,
+        bool _activateOnCreated,
+        bool _activateOnUpdated,
+        bool _activateOnDeleted,
+        string memory _registrationKey
+    ) public returns (RecipientSuperApp recipientSuperApp) {
+        recipientSuperApp = new RecipientSuperApp(
+        _recipient,
+        _strategy,
+        _host,
+        _acceptedToken,
+        _activateOnCreated,
+        _activateOnUpdated,
+        _activateOnDeleted,
+        _registrationKey
+        );
+    }
+}

--- a/contracts/strategies/_poc/sqf-superfluid/RecipientSuperAppFactory.sol
+++ b/contracts/strategies/_poc/sqf-superfluid/RecipientSuperAppFactory.sol
@@ -6,6 +6,12 @@ import {ISuperToken} from
 import "./RecipientSuperApp.sol";
 
 contract RecipientSuperAppFactory {
+    string registrationKey;
+
+    constructor(string memory _registrationKey) {
+        registrationKey = _registrationKey;
+    }
+
     function createRecipientSuperApp(
         address _recipient,
         address _strategy,
@@ -13,18 +19,17 @@ contract RecipientSuperAppFactory {
         ISuperToken _acceptedToken,
         bool _activateOnCreated,
         bool _activateOnUpdated,
-        bool _activateOnDeleted,
-        string memory _registrationKey
+        bool _activateOnDeleted
     ) public returns (RecipientSuperApp recipientSuperApp) {
         recipientSuperApp = new RecipientSuperApp(
-        _recipient,
-        _strategy,
-        _host,
-        _acceptedToken,
-        _activateOnCreated,
-        _activateOnUpdated,
-        _activateOnDeleted,
-        _registrationKey
+            _recipient,
+            _strategy,
+            _host,
+            _acceptedToken,
+            _activateOnCreated,
+            _activateOnUpdated,
+            _activateOnDeleted,
+            registrationKey
         );
     }
 }

--- a/contracts/strategies/_poc/sqf-superfluid/RecipientSuperAppFactory.sol
+++ b/contracts/strategies/_poc/sqf-superfluid/RecipientSuperAppFactory.sol
@@ -6,9 +6,15 @@ import {ISuperToken} from
 import "./RecipientSuperApp.sol";
 
 contract RecipientSuperAppFactory {
+    address deployer;
     string registrationKey;
 
-    constructor(string memory _registrationKey) {
+    constructor() {
+        deployer = msg.sender;
+    }
+
+    function setRegistrationKey(string memory _registrationKey) external {
+        require(msg.sender == deployer, "Only deployer may set registration key");
         registrationKey = _registrationKey;
     }
 

--- a/contracts/strategies/_poc/sqf-superfluid/SQFSuperFluidStrategy.sol
+++ b/contracts/strategies/_poc/sqf-superfluid/SQFSuperFluidStrategy.sol
@@ -457,8 +457,7 @@ contract SQFSuperFluidStrategy is BaseStrategy, ReentrancyGuard {
                     allocationSuperToken,
                     true,
                     true,
-                    true,
-                    ""
+                    true
                 );
 
                 allocationSuperToken.transfer(address(superApp), initialSuperAppBalance);

--- a/contracts/strategies/_poc/sqf-superfluid/SQFSuperFluidStrategy.sol
+++ b/contracts/strategies/_poc/sqf-superfluid/SQFSuperFluidStrategy.sol
@@ -22,6 +22,7 @@ import {BaseStrategy} from "../../BaseStrategy.sol";
 // Internal Libraries
 import {Metadata} from "../../../core/libraries/Metadata.sol";
 import {RecipientSuperApp} from "./RecipientSuperApp.sol";
+import {RecipientSuperAppFactory} from "./RecipientSuperAppFactory.sol";
 
 contract SQFSuperFluidStrategy is BaseStrategy, ReentrancyGuard {
     using SuperTokenV1Library for ISuperToken;
@@ -47,6 +48,7 @@ contract SQFSuperFluidStrategy is BaseStrategy, ReentrancyGuard {
         address passportDecoder;
         address superfluidHost;
         address allocationSuperToken;
+        address recipientSuperAppFactory;
         uint64 registrationStartTime;
         uint64 registrationEndTime;
         uint64 allocationStartTime;
@@ -117,6 +119,9 @@ contract SQFSuperFluidStrategy is BaseStrategy, ReentrancyGuard {
     /// @notice The pool super token
     ISuperToken public allocationSuperToken;
     ISuperToken public poolSuperToken;
+
+    /// @notice The recipient SuperApp factory
+    RecipientSuperAppFactory public recipientSuperAppFactory;
 
     /// @notice The GDA pool which streams pool tokens to recipients
     ISuperfluidPool public gdaPool;
@@ -218,6 +223,7 @@ contract SQFSuperFluidStrategy is BaseStrategy, ReentrancyGuard {
         metadataRequired = params.metadataRequired;
         superfluidHost = params.superfluidHost;
         minPassportScore = params.minPassportScore;
+        recipientSuperAppFactory = RecipientSuperAppFactory(params.recipientSuperAppFactory);
         _registry = allo.getRegistry();
 
         if (
@@ -444,7 +450,7 @@ contract SQFSuperFluidStrategy is BaseStrategy, ReentrancyGuard {
             emit Reviewed(recipientId, recipientStatus, msg.sender);
 
             if (recipientStatus == Status.Accepted) {
-                RecipientSuperApp superApp = new RecipientSuperApp(
+                RecipientSuperApp superApp = recipientSuperAppFactory.createRecipientSuperApp(
                     recipient.recipientAddress,
                     address(this),
                     superfluidHost,
@@ -452,7 +458,7 @@ contract SQFSuperFluidStrategy is BaseStrategy, ReentrancyGuard {
                     true,
                     true,
                     true,
-                    "" // regsitrationKey - for future create a superApp factory
+                    ""
                 );
 
                 allocationSuperToken.transfer(address(superApp), initialSuperAppBalance);

--- a/contracts/strategies/_poc/sqf-superfluid/SQFSuperFluidStrategy.sol
+++ b/contracts/strategies/_poc/sqf-superfluid/SQFSuperFluidStrategy.sol
@@ -451,13 +451,7 @@ contract SQFSuperFluidStrategy is BaseStrategy, ReentrancyGuard {
 
             if (recipientStatus == Status.Accepted) {
                 RecipientSuperApp superApp = recipientSuperAppFactory.createRecipientSuperApp(
-                    recipient.recipientAddress,
-                    address(this),
-                    superfluidHost,
-                    allocationSuperToken,
-                    true,
-                    true,
-                    true
+                    recipient.recipientAddress, address(this), superfluidHost, allocationSuperToken, true, true, true
                 );
 
                 allocationSuperToken.transfer(address(superApp), initialSuperAppBalance);

--- a/test/foundry/strategies/SQFSuperFluidStrategy.t.sol
+++ b/test/foundry/strategies/SQFSuperFluidStrategy.t.sol
@@ -100,7 +100,7 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
         allocationEndTime = uint64(block.timestamp) + uint64(2 days);
         minPassportScore = 69;
         initialSuperAppBalance = 420 * 1e8;
-        recipientSuperAppFactory = address(new RecipientSuperAppFactory());
+        recipientSuperAppFactory = address(new RecipientSuperAppFactory(""));
 
         // set empty app RegistrationKey
         vm.prank(superfluidOwner);

--- a/test/foundry/strategies/SQFSuperFluidStrategy.t.sol
+++ b/test/foundry/strategies/SQFSuperFluidStrategy.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.19;
 
 import {SQFSuperFluidStrategy} from "../../../contracts/strategies/_poc/sqf-superfluid/SQFSuperFluidStrategy.sol";
 import {RecipientSuperApp} from "../../../contracts/strategies/_poc/sqf-superfluid/RecipientSuperApp.sol";
+import {RecipientSuperAppFactory} from "../../../contracts/strategies/_poc/sqf-superfluid/RecipientSuperAppFactory.sol";
 
 import {Native} from "../../../contracts/core/libraries/Native.sol";
 import {Errors} from "../../../contracts/core/libraries/Errors.sol";
@@ -53,6 +54,7 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
     address passportDecoder;
     address superfluidHost;
     address allocationSuperToken;
+    address recipientSuperAppFactory;
     uint64 registrationStartTime;
     uint64 registrationEndTime;
     uint64 allocationStartTime;
@@ -98,6 +100,7 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
         allocationEndTime = uint64(block.timestamp) + uint64(2 days);
         minPassportScore = 69;
         initialSuperAppBalance = 420 * 1e8;
+        recipientSuperAppFactory = address(new RecipientSuperAppFactory());
 
         // set empty app RegistrationKey
         vm.prank(superfluidOwner);
@@ -844,7 +847,6 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
             )
         );
 
-
         vm.prank(pool_admin());
         vm.expectRevert(UNAUTHORIZED.selector);
         recipient.superApp.closeIncomingStream(address(this));
@@ -861,6 +863,7 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
             passportDecoder,
             superfluidHost,
             allocationSuperToken,
+            recipientSuperAppFactory,
             registrationStartTime,
             registrationEndTime,
             allocationStartTime,

--- a/test/foundry/strategies/SQFSuperFluidStrategy.t.sol
+++ b/test/foundry/strategies/SQFSuperFluidStrategy.t.sol
@@ -100,7 +100,8 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
         allocationEndTime = uint64(block.timestamp) + uint64(2 days);
         minPassportScore = 69;
         initialSuperAppBalance = 420 * 1e8;
-        recipientSuperAppFactory = address(new RecipientSuperAppFactory(""));
+        recipientSuperAppFactory = address(new RecipientSuperAppFactory());
+        RecipientSuperAppFactory(recipientSuperAppFactory).setRegistrationKey("");
 
         // set empty app RegistrationKey
         vm.prank(superfluidOwner);


### PR DESCRIPTION
Adds two emergency functions to the recipient Super Apps in the SQF Superfluid strategy to allow recipients to withdraw funds and close incoming streams.

Creates a factory to deploy the recipient Super Apps since the above change put the contract size over the deploy limit.

Also makes the Super App registration key configurable upon deployment to support deploying to mainnet.