### PR TITLE
fix: RecipientSuperAppFactory should register app

### DIFF
--- a/contracts/strategies/_poc/sqf-superfluid/RecipientSuperApp.sol
+++ b/contracts/strategies/_poc/sqf-superfluid/RecipientSuperApp.sol
@@ -48,36 +48,8 @@ contract RecipientSuperApp is ISuperApp {
         _;
     }
 
-    constructor(
-        address _recipient,
-        address _strategy,
-        address _host,
-        ISuperToken _acceptedToken,
-        bool _activateOnCreated,
-        bool _activateOnUpdated,
-        bool _activateOnDeleted,
-        string memory _registrationKey
-    ) {
+    constructor(address _recipient, address _strategy, address _host, ISuperToken _acceptedToken) {
         HOST = ISuperfluid(_host);
-
-        uint256 callBackDefinitions =
-            SuperAppDefinitions.APP_LEVEL_FINAL | SuperAppDefinitions.BEFORE_AGREEMENT_CREATED_NOOP;
-
-        if (!_activateOnCreated) {
-            callBackDefinitions |= SuperAppDefinitions.AFTER_AGREEMENT_CREATED_NOOP;
-        }
-
-        if (!_activateOnUpdated) {
-            callBackDefinitions |=
-                SuperAppDefinitions.BEFORE_AGREEMENT_UPDATED_NOOP | SuperAppDefinitions.AFTER_AGREEMENT_UPDATED_NOOP;
-        }
-
-        if (!_activateOnDeleted) {
-            callBackDefinitions |= SuperAppDefinitions.BEFORE_AGREEMENT_TERMINATED_NOOP
-                | SuperAppDefinitions.AFTER_AGREEMENT_TERMINATED_NOOP;
-        }
-
-        HOST.registerAppWithKey(callBackDefinitions, _registrationKey);
 
         if (address(_strategy) == address(0)) {
             revert ZERO_ADDRESS();

--- a/contracts/strategies/_poc/sqf-superfluid/RecipientSuperAppFactory.sol
+++ b/contracts/strategies/_poc/sqf-superfluid/RecipientSuperAppFactory.sol
@@ -1,23 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
-import {ISuperToken} from
+import {
+    ISuperfluid,
+    ISuperToken,
+    SuperAppDefinitions
+} from
     "../../../../lib/superfluid-protocol-monorepo/packages/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol";
 import "./RecipientSuperApp.sol";
 
 contract RecipientSuperAppFactory {
-    address deployer;
-    string registrationKey;
-
-    constructor() {
-        deployer = msg.sender;
-    }
-
-    function setRegistrationKey(string memory _registrationKey) external {
-        require(msg.sender == deployer, "Only deployer may set registration key");
-        registrationKey = _registrationKey;
-    }
-
     function createRecipientSuperApp(
         address _recipient,
         address _strategy,
@@ -27,15 +19,27 @@ contract RecipientSuperAppFactory {
         bool _activateOnUpdated,
         bool _activateOnDeleted
     ) public returns (RecipientSuperApp recipientSuperApp) {
-        recipientSuperApp = new RecipientSuperApp(
-            _recipient,
-            _strategy,
-            _host,
-            _acceptedToken,
-            _activateOnCreated,
-            _activateOnUpdated,
-            _activateOnDeleted,
-            registrationKey
-        );
+        ISuperfluid host = ISuperfluid(_host);
+
+        uint256 callBackDefinitions =
+            SuperAppDefinitions.APP_LEVEL_FINAL | SuperAppDefinitions.BEFORE_AGREEMENT_CREATED_NOOP;
+
+        if (!_activateOnCreated) {
+            callBackDefinitions |= SuperAppDefinitions.AFTER_AGREEMENT_CREATED_NOOP;
+        }
+
+        if (!_activateOnUpdated) {
+            callBackDefinitions |=
+                SuperAppDefinitions.BEFORE_AGREEMENT_UPDATED_NOOP | SuperAppDefinitions.AFTER_AGREEMENT_UPDATED_NOOP;
+        }
+
+        if (!_activateOnDeleted) {
+            callBackDefinitions |= SuperAppDefinitions.BEFORE_AGREEMENT_TERMINATED_NOOP
+                | SuperAppDefinitions.AFTER_AGREEMENT_TERMINATED_NOOP;
+        }
+
+        recipientSuperApp = new RecipientSuperApp(_recipient, _strategy, _host, _acceptedToken);
+
+        host.registerApp(recipientSuperApp, callBackDefinitions);
     }
 }

--- a/test/foundry/strategies/SQFSuperFluidStrategy.t.sol
+++ b/test/foundry/strategies/SQFSuperFluidStrategy.t.sol
@@ -101,7 +101,6 @@ contract SQFSuperFluidStrategyTest is RegistrySetupFullLive, AlloSetup, Native, 
         minPassportScore = 69;
         initialSuperAppBalance = 420 * 1e8;
         recipientSuperAppFactory = address(new RecipientSuperAppFactory());
-        RecipientSuperAppFactory(recipientSuperAppFactory).setRegistrationKey("");
 
         // set empty app RegistrationKey
         vm.prank(superfluidOwner);


### PR DESCRIPTION
Adding to https://github.com/allo-protocol/allo-v2/pull/474

Deploying on mainnet requires the factory to call `registerApp` and not the Super App.