### PR TITLE
chore: emit tx.origin in Allocated

### DIFF
--- a/contracts/strategies/donation-voting-merkle-base/DonationVotingMerkleDistributionBaseStrategy.sol
+++ b/contracts/strategies/donation-voting-merkle-base/DonationVotingMerkleDistributionBaseStrategy.sol
@@ -144,6 +144,14 @@ abstract contract DonationVotingMerkleDistributionBaseStrategy is Native, BaseSt
     /// @param sender The sender of the transaction
     event BatchPayoutSuccessful(address indexed sender);
 
+    /// @notice Emitted when a recipient is allocated funds
+    /// @param recipientId The id of the recipient
+    /// @param amount The amount of tokens allocated
+    /// @param token The address of the token
+    /// @param sender The sender of the transaction
+    /// @param origin The original sender of the transaction
+    event Allocated(address indexed recipientId, uint256 amount, address token, address sender, address origin);
+
     /// ================================
     /// ========== Storage =============
     /// ================================
@@ -691,7 +699,7 @@ abstract contract DonationVotingMerkleDistributionBaseStrategy is Native, BaseSt
         }
 
         // Emit that the amount has been allocated to the recipient by the sender
-        emit Allocated(recipientId, amount, token, _sender);
+        emit Allocated(recipientId, amount, token, _sender, tx.origin);
     }
 
     /// @notice Check if sender is profile owner or member.

--- a/test/foundry/strategies/DonationVotingMerkleDistributionBase.t.sol
+++ b/test/foundry/strategies/DonationVotingMerkleDistributionBase.t.sol
@@ -49,6 +49,7 @@ contract DonationVotingMerkleDistributionBaseMockTest is
         bytes32 profileId, uint256 nonce, string name, Metadata metadata, address indexed owner, address indexed anchor
     );
     event UpdatedRegistration(address indexed recipientId, bytes data, address sender, uint8 status);
+    event Allocated(address indexed recipientId, uint256 amount, address token, address sender, address origin);
 
     error InvalidSignature();
     error SignatureExpired(uint256);
@@ -997,7 +998,7 @@ contract DonationVotingMerkleDistributionBaseMockTest is
         vm.prank(randomAddress());
 
         vm.expectEmit(false, false, false, true);
-        emit Allocated(recipientId, 1e18, NATIVE, randomAddress());
+        emit Allocated(recipientId, 1e18, NATIVE, randomAddress(), tx.origin);
 
         allo().allocate{value: 1e18}(
             poolId, abi.encode(recipientId, DonationVotingMerkleDistributionBaseStrategy.PermitType.None, permit2Data)


### PR DESCRIPTION
This is not part of the audit but we wanted to emit the tx.origin on allocation as well 