### PR TITLE
fix

### DIFF
--- a/contracts/core/interfaces/IAllo.sol
+++ b/contracts/core/interfaces/IAllo.sol
@@ -37,7 +37,7 @@ interface IAllo {
         address token;
         Metadata metadata;
         bytes32 managerRole;
-        bytes32 adminRole;
+        bytes32 adminRole;   
     }
 
     /// ======================


### PR DESCRIPTION
https://sepolia.etherscan.io/tx/0x82f59ac8060f83c86e9b61f6a45aeba7c704ffd7e648be8dcdfaacbc5e1ca970
- Currently cannot add multiple admin for a pool
- We would have to make a change like this on the contract level on allo and registry
- While change is simple -> q: would it be nicer to default to safe