### PR TITLE
feat: implement erc2771

### DIFF
--- a/contracts/core/Allo.sol
+++ b/contracts/core/Allo.sol
@@ -118,7 +118,8 @@ contract Allo is
         // Set the base fee
         _updateBaseFee(_baseFee);
 
-        _trustedForwarder = __trustedForwarder;
+        // Set the trusted forwarder
+        _updateTrustedForwarder(__trustedForwarder);
     }
 
     // ====================================
@@ -259,6 +260,13 @@ contract Allo is
     /// @param _baseFee The new base fee
     function updateBaseFee(uint256 _baseFee) external onlyOwner {
         _updateBaseFee(_baseFee);
+    }
+
+    /// @notice Updates the trusted forwarder address.
+    /// @dev Use this to update the trusted forwarder address.
+    /// @param __trustedForwarder The new trusted forwarder address
+    function updateTrustedForwarder(address __trustedForwarder) external onlyOwner {
+        _updateTrustedForwarder(__trustedForwarder);
     }
 
     /// @notice Add multiple pool managers
@@ -644,6 +652,18 @@ contract Allo is
         baseFee = _baseFee;
 
         emit BaseFeeUpdated(baseFee);
+    }
+
+    /// @notice Updates the trusted forwarder address
+    /// @dev Internal function used to update the trusted forwarder address.
+    ///      Emits a TrustedForwarderUpdated event.
+    /// @param __trustedForwarder The new trusted forwarder address
+    function _updateTrustedForwarder(address __trustedForwarder) internal {
+        if (__trustedForwarder == address(0)) revert ZERO_ADDRESS();
+
+        _trustedForwarder = __trustedForwarder;
+
+        emit TrustedForwarderUpdated(__trustedForwarder);
     }
 
     /// @notice Adds a pool manager

--- a/contracts/core/Allo.sol
+++ b/contracts/core/Allo.sol
@@ -79,6 +79,9 @@ contract Allo is
     /// @dev 'Pool.id' -> 'Pool'
     mapping(uint256 => Pool) private pools;
 
+    /// @custom:oz-upgrades-renamed-from cloneableStrategies
+    mapping(address => bool) private _unusedSlot;
+
     /// @notice The trusted forwarder contract address
     /// @dev Based on ERC2771ContextUpgradeable OZ contracts
     address private _trustedForwarder;

--- a/contracts/core/Allo.sol
+++ b/contracts/core/Allo.sol
@@ -681,9 +681,8 @@ contract Allo is
     /// @dev Logic copied from ERC2771ContextUpgradeable OZ contracts
     function _msgSender() internal view virtual override returns (address) {
         uint256 calldataLength = msg.data.length;
-        uint256 contextSuffixLength = _contextSuffixLength();
-        if (isTrustedForwarder(msg.sender) && calldataLength >= contextSuffixLength) {
-            return address(bytes20(msg.data[calldataLength - contextSuffixLength:]));
+        if (isTrustedForwarder(msg.sender) && calldataLength >= 20) {
+            return address(bytes20(msg.data[calldataLength - 20:]));
         } else {
             return super._msgSender();
         }
@@ -692,17 +691,11 @@ contract Allo is
     /// @dev Logic copied from ERC2771ContextUpgradeable OZ contracts
     function _msgData() internal view virtual override returns (bytes calldata) {
         uint256 calldataLength = msg.data.length;
-        uint256 contextSuffixLength = _contextSuffixLength();
-        if (isTrustedForwarder(msg.sender) && calldataLength >= contextSuffixLength) {
-            return msg.data[:calldataLength - contextSuffixLength];
+        if (isTrustedForwarder(msg.sender) && calldataLength >= 20) {
+            return msg.data[:calldataLength - 20];
         } else {
             return super._msgData();
         }
-    }
-
-    /// @dev Logic copied from ERC2771ContextUpgradeable OZ contracts
-    function _contextSuffixLength() internal view returns (uint256) {
-        return 20;
     }
 
     // =========================

--- a/contracts/core/interfaces/IAllo.sol
+++ b/contracts/core/interfaces/IAllo.sol
@@ -92,6 +92,10 @@ interface IAllo {
     /// @param registry Address of the new registry
     event RegistryUpdated(address registry);
 
+    /// @notice Emitted when the trusted forwarder is updated
+    /// @param trustedForwarder Address of the new trusted forwarder
+    event TrustedForwarderUpdated(address trustedForwarder);
+
     /// ====================================
     /// ==== External/Public Functions =====
     /// ====================================

--- a/contracts/core/interfaces/IAllo.sol
+++ b/contracts/core/interfaces/IAllo.sol
@@ -102,12 +102,14 @@ interface IAllo {
     /// @param _treasury Address of the treasury
     /// @param _percentFee Percentage for the fee
     /// @param _baseFee Base fee amount
+    /// @param __trustedForwarder The address of the trusted forwarder
     function initialize(
         address _owner,
         address _registry,
         address payable _treasury,
         uint256 _percentFee,
-        uint256 _baseFee
+        uint256 _baseFee,
+        address __trustedForwarder
     ) external;
 
     /// @notice Creates a new pool (with a custom strategy)

--- a/contracts/core/interfaces/IAllo.sol
+++ b/contracts/core/interfaces/IAllo.sol
@@ -289,4 +289,9 @@ interface IAllo {
     /// @dev 1e18 represents 100%
     /// @return feeDenominator The current fee denominator
     function getFeeDenominator() external view returns (uint256);
+
+    /// @notice Returns TRUE if the forwarder is trusted
+    /// @param forwarder The address of the forwarder to check
+    /// @return 'true' if the forwarder is trusted, otherwise 'false'
+    function isTrustedForwarder(address forwarder) external view returns (bool);
 }

--- a/test/foundry/core/Allo.t.sol
+++ b/test/foundry/core/Allo.t.sol
@@ -735,16 +735,18 @@ contract AlloTest is Test, AlloSetup, RegistrySetupFull, Native, Errors, GasHelp
         assertEq(mockAllo.mockMsgData(), abi.encodeWithSelector(mockAllo.mockMsgData.selector));
     }
 
-    function test__msgData_trustedForwarder(bytes memory _data) public {
-        vm.skip(true);
-
-        // append the data to the data
-        bytes memory data = abi.encodeWithSelector(mockAllo.mockMsgData.selector, _data);
+    function test__msgData_trustedForwarder(address _sender) public {
+        // append the sender to the data
+        bytes memory data = abi.encodeWithSelector(mockAllo.mockMsgData.selector, _sender);
 
         vm.prank(trustedForwarder());
         (, bytes memory encodedData) = address(mockAllo).call(data);
 
-        // decode the received sender
-        assertEq(abi.decode(encodedData, (bytes)), abi.encodeWithSelector(mockAllo.mockMsgData.selector));
+        // decode the received data
+        bytes memory decodedData = abi.decode(encodedData, (bytes));
+
+        // since the slicing inside of _msgData keeps the padding at the end, 
+        // we need to extract only the selector in order to compare it
+        assertEq(mockAllo.extractSelector(decodedData), abi.encodeWithSelector(mockAllo.mockMsgData.selector));
     }
 }

--- a/test/foundry/core/Allo.t.sol
+++ b/test/foundry/core/Allo.t.sol
@@ -95,13 +95,15 @@ contract AlloTest is Test, AlloSetup, RegistrySetupFull, Native, Errors, GasHelp
             address(registry()), // _registry
             allo_treasury(), // _treasury
             1e16, // _percentFee
-            1e15 // _baseFee
+            1e15, // _baseFee
+            trustedForwarder() // _trustedForwarder
         );
 
         assertEq(address(coreContract.getRegistry()), address(registry()));
         assertEq(coreContract.getTreasury(), allo_treasury());
         assertEq(coreContract.getPercentFee(), 1e16);
         assertEq(coreContract.getBaseFee(), 1e15);
+        assertTrue(coreContract.isTrustedForwarder(trustedForwarder()));
     }
 
     function testRevert_initialize_ALREADY_INITIALIZED() public {
@@ -112,7 +114,8 @@ contract AlloTest is Test, AlloSetup, RegistrySetupFull, Native, Errors, GasHelp
             address(registry()), // _registry
             allo_treasury(), // _treasury
             1e16, // _percentFee
-            1e15 // _baseFee
+            1e15, // _baseFee
+            trustedForwarder() // _trustedForwarder
         );
     }
 

--- a/test/foundry/core/Allo.t.sol
+++ b/test/foundry/core/Allo.t.sol
@@ -745,7 +745,7 @@ contract AlloTest is Test, AlloSetup, RegistrySetupFull, Native, Errors, GasHelp
         // decode the received data
         bytes memory decodedData = abi.decode(encodedData, (bytes));
 
-        // since the slicing inside of _msgData keeps the padding at the end, 
+        // since the slicing inside of _msgData keeps the padding at the end,
         // we need to extract only the selector in order to compare it
         assertEq(mockAllo.extractSelector(decodedData), abi.encodeWithSelector(mockAllo.mockMsgData.selector));
     }

--- a/test/foundry/core/Allo.t.sol
+++ b/test/foundry/core/Allo.t.sol
@@ -40,6 +40,7 @@ contract AlloTest is Test, AlloSetup, RegistrySetupFull, Native, Errors, GasHelp
     event RegistryUpdated(address registry);
     event StrategyApproved(address strategy);
     event StrategyRemoved(address strategy);
+    event TrustedForwarderUpdated(address trustedForwarder);
 
     error AlreadyInitialized();
 
@@ -347,6 +348,24 @@ contract AlloTest is Test, AlloSetup, RegistrySetupFull, Native, Errors, GasHelp
 
         vm.prank(makeAddr("anon"));
         allo().updateBaseFee(1e16);
+    }
+
+    function test_updateTrustedForwarder(address _trustedForwarder) public {
+        vm.assume(_trustedForwarder != address(0));
+
+        vm.expectEmit(true, false, false, false);
+
+        emit TrustedForwarderUpdated(_trustedForwarder);
+
+        allo().updateTrustedForwarder(_trustedForwarder);
+
+        assertTrue(allo().isTrustedForwarder(_trustedForwarder));
+    }
+
+    function test_updateTrustedForwarder_UNAUTHORIZED() public {
+        vm.expectRevert(Errors.ZERO_ADDRESS.selector);
+
+        allo().updateTrustedForwarder(address(0));
     }
 
     function test_addPoolManagers(address[] memory _poolManagersToAdd) public {

--- a/test/foundry/integration/Allo.t.sol
+++ b/test/foundry/integration/Allo.t.sol
@@ -4,21 +4,16 @@ pragma solidity ^0.8.19;
 import {Test, console} from "forge-std/Test.sol";
 import {Allo} from "../../../contracts/core/Allo.sol";
 import {Registry, Metadata} from "../../../contracts/core/Registry.sol";
-import {DonationVotingMerkleDistributionDirectTransferStrategy} from "../../../contracts/strategies/donation-voting-merkle-distribution-direct-transfer/DonationVotingMerkleDistributionDirectTransferStrategy.sol";
+import {DonationVotingMerkleDistributionDirectTransferStrategy} from
+    "../../../contracts/strategies/donation-voting-merkle-distribution-direct-transfer/DonationVotingMerkleDistributionDirectTransferStrategy.sol";
+import {DonationVotingMerkleDistributionBaseStrategy} from
+    "../../../contracts/strategies/donation-voting-merkle-base/DonationVotingMerkleDistributionBaseStrategy.sol";
 import {ISignatureTransfer} from "permit2/ISignatureTransfer.sol";
 import {IBiconomyForwarder} from "./IBiconomyForwarder.sol";
-import {ECDSA} from 'openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol';
+import {ECDSA} from "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
 
 contract IntegrationAllo is Test {
-    struct InitializeData {
-        bool useRegistryAnchor;
-        bool metadataRequired;
-        uint64 registrationStartTime;
-        uint64 registrationEndTime;
-        uint64 allocationStartTime;
-        uint64 allocationEndTime;
-        address[] allowedTokens;
-    }
+    using ECDSA for bytes32;
 
     Allo public allo;
     Registry public registry;
@@ -27,7 +22,9 @@ contract IntegrationAllo is Test {
     address public owner;
     address public relayer;
     address public treasury;
-    address public user;
+    address public userAddr;
+
+    uint256 public userPk;
 
     bytes32 public profileId;
 
@@ -35,77 +32,89 @@ contract IntegrationAllo is Test {
     address public constant dai = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
 
     function setUp() public {
-        vm.createSelectFork(vm.rpcUrl('mainnet'));
+        vm.createSelectFork(vm.rpcUrl("mainnet"), 20289932);
 
-        owner = makeAddr('owner');
-        treasury = makeAddr('treasury');
-        user = makeAddr('user');
+        owner = makeAddr("owner");
+        treasury = makeAddr("treasury");
+        (userAddr, userPk) = makeAddrAndKey("user");
 
         allo = new Allo();
         registry = new Registry();
-        strategy = new DonationVotingMerkleDistributionDirectTransferStrategy(address(allo), "Test Strategy", ISignatureTransfer(address(1)));
-
-        allo.initialize(
-            owner,
-            address(registry),
-            payable(treasury),
-            0,
-            0,
-            biconomyForwarder
+        strategy = new DonationVotingMerkleDistributionDirectTransferStrategy(
+            address(allo), "Test Strategy", ISignatureTransfer(address(1))
         );
 
+        allo.initialize(owner, address(registry), payable(treasury), 0, 0, biconomyForwarder);
         registry.initialize(owner);
 
-        vm.prank(user);
-        profileId = registry.createProfile(0, "Test Profile", Metadata({
-            protocol: 1,
-            pointer: ''
-        }), user, new address[](0));
+        vm.prank(userAddr);
+        profileId =
+            registry.createProfile(0, "Test Profile", Metadata({protocol: 1, pointer: ""}), userAddr, new address[](0));
     }
 
     function test_CreatePoolWithMetaTx() public {
-        bytes memory _initStrategyData = abi.encode(InitializeData({
-            useRegistryAnchor: false,
-            metadataRequired: false,
-            registrationStartTime: uint64(block.timestamp), 
-            registrationEndTime: uint64(block.timestamp + 7 days),
-            allocationStartTime: uint64(block.timestamp),
-            allocationEndTime: uint64(block.timestamp + 7 days),
-            allowedTokens: new address[](0)
-        }));
+        bytes memory _initStrategyData = abi.encode(
+            DonationVotingMerkleDistributionBaseStrategy.InitializeData({
+                useRegistryAnchor: false,
+                metadataRequired: false,
+                registrationStartTime: uint64(block.timestamp),
+                registrationEndTime: uint64(block.timestamp + 7 days),
+                allocationStartTime: uint64(block.timestamp),
+                allocationEndTime: uint64(block.timestamp + 7 days),
+                allowedTokens: new address[](0)
+            })
+        );
 
         bytes32 domainSeparator = 0x4fde6db5140ab711910b567033f2d5e64dc4f7123d722004dd748edf6ed07abb; // Biconomy Forwarder
 
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(0x00, '');
+        // User signs the request
+        IBiconomyForwarder.ERC20ForwardRequest memory req = IBiconomyForwarder.ERC20ForwardRequest({
+            from: userAddr,
+            to: address(allo),
+            token: dai,
+            txGas: 500_000,
+            tokenGasPrice: 0,
+            batchId: 0,
+            batchNonce: 0,
+            deadline: block.timestamp + 1 days,
+            data: abi.encodeWithSelector(
+                allo.createPool.selector,
+                profileId,
+                address(strategy),
+                _initStrategyData,
+                dai,
+                0,
+                Metadata({protocol: 1, pointer: ""}),
+                new address[](0)
+            )
+        });
+        bytes32 structHash = keccak256(
+            abi.encode(
+                IBiconomyForwarder(biconomyForwarder).REQUEST_TYPEHASH(),
+                req.from,
+                req.to,
+                req.token,
+                req.txGas,
+                req.tokenGasPrice,
+                req.batchId,
+                0, // TODO: remove hardcoded nonce
+                req.deadline,
+                keccak256(req.data)
+            )
+        );
+        bytes32 digest = domainSeparator.toTypedDataHash(structHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(userPk, digest);
         bytes memory sig = abi.encodePacked(r, s, v);
 
+        // Relayer submits the request
         vm.prank(relayer);
-        IBiconomyForwarder(biconomyForwarder).executeEIP712(
-            IBiconomyForwarder.ERC20ForwardRequest({
-                from: user,
-                to: address(allo),
-                token: dai,
-                txGas: 0,
-                tokenGasPrice: 0,
-                batchId: 0,
-                batchNonce: 0,
-                deadline: block.timestamp + 1 days,
-                data: abi.encodeWithSelector(
-                    allo.createPool.selector,
-                    profileId,
-                    address(strategy),
-                    _initStrategyData,
-                    dai,
-                    0,
-                    Metadata({
-                        protocol: 1,
-                        pointer: ''
-                    }),
-                    new address[](0)
-                )
-            }),
-            domainSeparator,
-            sig
-        );
+        (bool success, bytes memory ret) =
+            IBiconomyForwarder(biconomyForwarder).executeEIP712(req, domainSeparator, sig);
+
+        // Check that the pool was created
+        uint256 poolId = abi.decode(ret, (uint256));
+        assertTrue(success);
+        assertTrue(allo.isPoolAdmin(poolId, userAddr));
+        assertFalse(allo.isPoolAdmin(poolId, relayer));
     }
 }

--- a/test/foundry/integration/Allo.t.sol
+++ b/test/foundry/integration/Allo.t.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.19;
+
+import {Test, console} from "forge-std/Test.sol";
+import {Allo} from "../../../contracts/core/Allo.sol";
+import {Registry, Metadata} from "../../../contracts/core/Registry.sol";
+import {DonationVotingMerkleDistributionDirectTransferStrategy} from "../../../contracts/strategies/donation-voting-merkle-distribution-direct-transfer/DonationVotingMerkleDistributionDirectTransferStrategy.sol";
+import {ISignatureTransfer} from "permit2/ISignatureTransfer.sol";
+
+contract IntegrationAllo is Test {
+    struct InitializeData {
+        bool useRegistryAnchor;
+        bool metadataRequired;
+        uint64 registrationStartTime;
+        uint64 registrationEndTime;
+        uint64 allocationStartTime;
+        uint64 allocationEndTime;
+        address[] allowedTokens;
+    }
+
+    Allo public allo;
+    Registry public registry;
+    DonationVotingMerkleDistributionDirectTransferStrategy public strategy;
+
+    address public owner;
+    address public user;
+    address public relay;
+    address public treasury;
+
+    bytes32 public profileId;
+
+    address public constant biconomyForwarder = 0x84a0856b038eaAd1cC7E297cF34A7e72685A8693;
+    address public constant dai = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+
+    function setUp() public {
+        vm.createSelectFork(vm.rpcUrl('mainnet'));
+
+        owner = makeAddr('owner');
+        treasury = makeAddr('treasury');
+        user = makeAddr('user');
+
+        allo = new Allo();
+        registry = new Registry();
+        strategy = new DonationVotingMerkleDistributionDirectTransferStrategy(address(allo), "Test Strategy", ISignatureTransfer(address(1)));
+
+        allo.initialize(
+            owner,
+            address(registry),
+            payable(treasury),
+            0,
+            0,
+            biconomyForwarder
+        );
+
+        registry.initialize(owner);
+
+        vm.prank(user);
+        profileId = registry.createProfile(0, "Test Profile", Metadata({
+            protocol: 1,
+            pointer: ''
+        }), user, new address[](0));
+    }
+
+    function test_CreatePoolWithMetaTx() public {
+        bytes memory _initStrategyData = abi.encode(InitializeData({
+            useRegistryAnchor: false,
+            metadataRequired: false,
+            registrationStartTime: uint64(block.timestamp), 
+            registrationEndTime: uint64(block.timestamp + 7 days),
+            allocationStartTime: uint64(block.timestamp),
+            allocationEndTime: uint64(block.timestamp + 7 days),
+            allowedTokens: new address[](0)
+        }));
+
+        vm.prank(user);
+        allo.createPool(
+            profileId,
+            address(strategy),
+            _initStrategyData,
+            dai,
+            0,
+            Metadata({
+                protocol: 1,
+                pointer: ''
+            }),
+            new address[](0)
+        );
+    }
+}

--- a/test/foundry/integration/IBiconomyForwarder.sol
+++ b/test/foundry/integration/IBiconomyForwarder.sol
@@ -3,20 +3,20 @@ pragma solidity 0.8.19;
 
 interface IBiconomyForwarder {
     struct ERC20ForwardRequest {
-        address from; 
-        address to; 
-        address token; 
+        address from;
+        address to;
+        address token;
         uint256 txGas;
         uint256 tokenGasPrice;
-        uint256 batchId; 
-        uint256 batchNonce; 
-        uint256 deadline; 
+        uint256 batchId;
+        uint256 batchNonce;
+        uint256 deadline;
         bytes data;
     }
 
-    function executeEIP712(
-        ERC20ForwardRequest calldata req,
-        bytes32 domainSeparator,
-        bytes calldata sig
-    ) external returns (bool success, bytes memory ret);
+    function executeEIP712(ERC20ForwardRequest calldata req, bytes32 domainSeparator, bytes calldata sig)
+        external
+        returns (bool success, bytes memory ret);
+
+    function REQUEST_TYPEHASH() external view returns (bytes32);
 }

--- a/test/foundry/integration/IBiconomyForwarder.sol
+++ b/test/foundry/integration/IBiconomyForwarder.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.19;
+
+interface IBiconomyForwarder {
+    struct ERC20ForwardRequest {
+        address from; 
+        address to; 
+        address token; 
+        uint256 txGas;
+        uint256 tokenGasPrice;
+        uint256 batchId; 
+        uint256 batchNonce; 
+        uint256 deadline; 
+        bytes data;
+    }
+
+    function executeEIP712(
+        ERC20ForwardRequest calldata req,
+        bytes32 domainSeparator,
+        bytes calldata sig
+    ) external returns (bool success, bytes memory ret);
+}

--- a/test/foundry/shared/Accounts.sol
+++ b/test/foundry/shared/Accounts.sol
@@ -24,6 +24,10 @@ contract Accounts is StdCheats {
         return payable(makeAddr("allo_treasury"));
     }
 
+    function trustedForwarder() public virtual returns (address) {
+        return makeAddr("trustedForwarder");
+    }
+
     // //////////////////////
     // Null Profile adresses
     // //////////////////////

--- a/test/foundry/shared/AlloSetup.sol
+++ b/test/foundry/shared/AlloSetup.sol
@@ -19,7 +19,8 @@ contract AlloSetup is Test, Accounts {
             _registry, // _registry
             allo_treasury(), // _treasury
             1e16, // _percentFee
-            0 // _baseFee
+            0, // _baseFee
+            trustedForwarder() // _trustedForwarder
         );
         vm.stopPrank();
     }

--- a/test/utils/MockAllo.sol
+++ b/test/utils/MockAllo.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.19;
+
+import { Allo } from "../../contracts/core/Allo.sol";
+
+contract MockAllo is Allo {
+    function mockMsgSender() external view returns (address) {
+        return _msgSender();
+    }
+
+    function mockMsgData() external view returns (bytes calldata) {
+        return _msgData();
+    }
+}

--- a/test/utils/MockAllo.sol
+++ b/test/utils/MockAllo.sol
@@ -11,4 +11,9 @@ contract MockAllo is Allo {
     function mockMsgData() external view returns (bytes calldata) {
         return _msgData();
     }
+
+    /// @notice Slices the selector from the data
+    function extractSelector(bytes calldata _data) external pure returns (bytes memory) {
+        return _data[:4];
+    }
 }

--- a/test/utils/MockAllo.sol
+++ b/test/utils/MockAllo.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.19;
 
-import { Allo } from "../../contracts/core/Allo.sol";
+import {Allo} from "../../contracts/core/Allo.sol";
 
 contract MockAllo is Allo {
     function mockMsgSender() external view returns (address) {


### PR DESCRIPTION
Closes #594

- [x] Copy erc2771 logic from ERC2771ContextUpgradeable OpenZeppelin contracts (avoided inheritance to preserve storage layout).
- [x] Add tests for `_msgData` and `_msgSender`.
- [x] Add integration test.