### PR TITLE
feat: make reviewRecipients more customizable

### DIFF
--- a/contracts/extensions/contracts/RecipientsExtension.sol
+++ b/contracts/extensions/contracts/RecipientsExtension.sol
@@ -8,6 +8,9 @@ import {Metadata} from "../../core/libraries/Metadata.sol";
 import {Errors} from "../../core/libraries/Errors.sol";
 
 abstract contract RecipientsExtension is CoreBaseStrategy, Errors, IRecipientsExtension {
+    /// @notice if set to true, `_reviewRecipientStatus()` is called for each new status update.
+    bool public immutable REVIEW_EACH_STATUS;
+
     /// @notice Flag to indicate whether metadata is required or not.
     bool public metadataRequired;
 
@@ -35,12 +38,21 @@ abstract contract RecipientsExtension is CoreBaseStrategy, Errors, IRecipientsEx
     /// and convert it to the 2-bits position in the bitmap.
     mapping(uint256 => uint256) public statusesBitMap;
 
-    /// @notice 'recipientId' => 'statusIndex'
-    /// @dev 'statusIndex' is the index of the recipient in the 'statusesBitMap' bitmap.
-    mapping(address => uint256) public recipientToStatusIndexes;
+    /// @notice 'statusIndex' of recipient in bitmap => 'recipientId'.
+    mapping(uint256 => address) public statusIndexToRecipientId;
 
     /// @notice 'recipientId' => 'Recipient' struct.
     mapping(address => Recipient) internal _recipients;
+
+    /// ====================================
+    /// ========== Constructor =============
+    /// ====================================
+
+    /// @notice Constructor to set the Allo contract
+    /// @param _allo Address of the Allo contract.
+    constructor(bool _reviewEachStatus) {
+        REVIEW_EACH_STATUS = _reviewEachStatus;
+    }
 
     /// @notice Modifier to check if the registration is active
     /// @dev This will revert if the registration has not started or if the registration has ended.
@@ -101,28 +113,44 @@ abstract contract RecipientsExtension is CoreBaseStrategy, Errors, IRecipientsEx
     /// Emits the RecipientStatusUpdated() event.
     /// @param statuses new statuses
     /// @param refRecipientsCounter the recipientCounter the transaction is based on
-    function reviewRecipients(ApplicationStatus[] memory statuses, uint256 refRecipientsCounter)
-        public
-        virtual
-        onlyPoolManager(msg.sender)
-    {
+    function reviewRecipients(ApplicationStatus[] memory statuses, uint256 refRecipientsCounter) public virtual {
+        _validateReviewRecipients(msg.sender);
         if (refRecipientsCounter != recipientsCounter) revert INVALID();
         // Loop through the statuses and set the status
-        uint256 length = statuses.length;
-        for (uint256 i; i < length;) {
+        for (uint256 i; i < statuses.length; i++) {
             uint256 rowIndex = statuses[i].index;
             uint256 fullRow = statuses[i].statusRow;
+
+            if (REVIEW_EACH_STATUS) {
+                // Loop through each status in the updated row
+                uint256 currentRow = statusesBitMap[rowIndex];
+                for (uint256 col = 0; j < 64; col++) {
+                    uint8 newStatus = uint8((fullRow >> col * 4) & 0xF);
+                    uint8 currentStatus = uint8((currentRow >> col * 4) & 0xF);
+
+                    if (newStatus != currentStatus) {
+                        uint256 recipientIndex = rowIndex * 64 + col + 1;
+                        _reviewRecipientStatus(Status(newStatus), recipientIndex);
+                    }
+
+                    unchecked {
+                        col++;
+                    }
+                }
+            }
 
             statusesBitMap[rowIndex] = fullRow;
 
             // Emit that the recipient status has been updated with the values
             emit RecipientStatusUpdated(rowIndex, fullRow, msg.sender);
-
-            unchecked {
-                i++;
-            }
         }
     }
+
+    function _validateReviewRecipients(address _sender) internal virtual {
+        _checkOnlyPoolManager(_sender);
+    }
+
+    function _reviewRecipientStatus(Status _newStatus, uint256 _recipientIndex) internal virtual {}
 
     /// @notice Sets the start and end dates.
     /// @dev The 'msg.sender' must be a pool manager.
@@ -227,9 +255,10 @@ abstract contract RecipientsExtension is CoreBaseStrategy, Errors, IRecipientsEx
             recipient.metadata = metadata;
             recipient.useRegistryAnchor = isUsingRegistryAnchor;
 
-            if (recipientToStatusIndexes[recipientId] == 0) {
+            if (recipient.statusIndex == 0) {
                 // recipient registering new application
-                recipientToStatusIndexes[recipientId] = recipientsCounter;
+                recipient.statusIndex = recipientsCounter;
+                statusIndexToRecipientId[recipientsCounter] = recipientId;
                 _setRecipientStatus(recipientId, uint8(Status.Pending));
 
                 bytes memory extendedData = abi.encode(data, recipientsCounter);
@@ -311,7 +340,7 @@ abstract contract RecipientsExtension is CoreBaseStrategy, Errors, IRecipientsEx
     /// @param _recipientId ID of the recipient
     /// @return status The status of the recipient
     function _getUintRecipientStatus(address _recipientId) internal view virtual returns (uint8 status) {
-        if (recipientToStatusIndexes[_recipientId] == 0) return 0;
+        if (_recipients[_recipientId].statusIndex == 0) return 0;
         // Get the column index and current row
         (, uint256 colIndex, uint256 currentRow) = _getStatusRowColumn(_recipientId);
 
@@ -326,7 +355,7 @@ abstract contract RecipientsExtension is CoreBaseStrategy, Errors, IRecipientsEx
     /// @param _recipientId ID of the recipient
     /// @return (rowIndex, colIndex, currentRow)
     function _getStatusRowColumn(address _recipientId) internal view virtual returns (uint256, uint256, uint256) {
-        uint256 recipientIndex = recipientToStatusIndexes[_recipientId] - 1;
+        uint256 recipientIndex = _recipients[_recipientId].statusIndex - 1;
 
         uint256 rowIndex = recipientIndex / 64; // 256 / 4
         uint256 colIndex = (recipientIndex % 64) * 4;

--- a/contracts/extensions/contracts/RecipientsExtension.sol
+++ b/contracts/extensions/contracts/RecipientsExtension.sol
@@ -363,7 +363,7 @@ abstract contract RecipientsExtension is CoreBaseStrategy, Errors, IRecipientsEx
 
             // Only do something if the status is being modified
             if (newStatus != currentStatus) {
-                uint256 recipientIndex = _rowIndex << 6 + col + 1; // _rowIndex * 64 + col + 1
+                uint256 recipientIndex = (_rowIndex << 6) + col + 1; // _rowIndex * 64 + col + 1
                 Status reviewedStatus = _reviewRecipientStatus(Status(newStatus), Status(currentStatus), recipientIndex);
                 if (reviewedStatus != Status(newStatus)) {
                     // Update `_fullRow` with the reviewed status.

--- a/contracts/extensions/contracts/RecipientsExtension.sol
+++ b/contracts/extensions/contracts/RecipientsExtension.sol
@@ -39,7 +39,7 @@ abstract contract RecipientsExtension is CoreBaseStrategy, Errors, IRecipientsEx
     mapping(uint256 => uint256) public statusesBitMap;
 
     /// @notice 'statusIndex' of recipient in bitmap => 'recipientId'.
-    mapping(uint256 => address) public statusIndexToRecipientId;
+    mapping(uint256 => address) public recipientIndexToRecipientId;
 
     /// @notice 'recipientId' => 'Recipient' struct.
     mapping(address => Recipient) internal _recipients;
@@ -258,7 +258,7 @@ abstract contract RecipientsExtension is CoreBaseStrategy, Errors, IRecipientsEx
             if (recipient.statusIndex == 0) {
                 // recipient registering new application
                 recipient.statusIndex = recipientsCounter;
-                statusIndexToRecipientId[recipientsCounter] = recipientId;
+                recipientIndexToRecipientId[recipientsCounter] = recipientId;
                 _setRecipientStatus(recipientId, uint8(Status.Pending));
 
                 bytes memory extendedData = abi.encode(data, recipientsCounter);

--- a/contracts/extensions/contracts/RecipientsExtension.sol
+++ b/contracts/extensions/contracts/RecipientsExtension.sol
@@ -349,7 +349,7 @@ abstract contract RecipientsExtension is CoreBaseStrategy, Errors, IRecipientsEx
     }
 
     /// @notice Called from reviewRecipients if REVIEW_EACH_STATUS is set to true.
-    /// @dev Each new status in the statuses row (_fullrow) gets isolated and sent to _reviewRecipientStatus for review
+    /// @dev Each new status in the statuses row (_fullrow) gets isolated and sent to _reviewRecipientStatus for review.
     /// @param _rowIndex Row index in the statusesBitMap mapping
     /// @param _fullRow New row of statuses
     function _processStatusRow(uint256 _rowIndex, uint256 _fullRow) internal returns (uint256) {
@@ -386,7 +386,8 @@ abstract contract RecipientsExtension is CoreBaseStrategy, Errors, IRecipientsEx
         _checkOnlyPoolManager(_sender);
     }
 
-    /// @notice Hook to review each new recipient status
+    /// @notice Hook to review each new recipient status when REVIEW_EACH_STATUS is set to true
+    /// @dev Beware of gas costs, since this function will be called for each reviewed recipient
     /// @param _newStatus New proposed status
     /// @param _oldStatus Previous status
     /// @param _recipientIndex The index of the recipient in case the recipient data needs to be accessed

--- a/contracts/extensions/contracts/RecipientsExtension.sol
+++ b/contracts/extensions/contracts/RecipientsExtension.sol
@@ -148,10 +148,10 @@ abstract contract RecipientsExtension is CoreBaseStrategy, Errors, IRecipientsEx
             if (newStatus != currentStatus) {
                 uint256 recipientIndex = _rowIndex << 6 + col + 1; // _rowIndex * 64 + col + 1
                 Status reviewedStatus = _reviewRecipientStatus(Status(newStatus), Status(currentStatus), recipientIndex);
-                if (reviewedStatus != newStatus) {
+                if (reviewedStatus != Status(newStatus)) {
                     // Update `_fullRow` with the reviewed status.
                     uint256 reviewedRow = _fullRow & ~(0xF << colIndex);
-                    _fullRow = reviewedRow | (reviewedStatus << colIndex);
+                    _fullRow = reviewedRow | (uint256(reviewedStatus) << colIndex);
                 }
             }
 
@@ -280,7 +280,7 @@ abstract contract RecipientsExtension is CoreBaseStrategy, Errors, IRecipientsEx
 
             if (recipient.statusIndex == 0) {
                 // recipient registering new application
-                recipient.statusIndex = recipientsCounter;
+                recipient.statusIndex = uint64(recipientsCounter);
                 recipientIndexToRecipientId[recipientsCounter] = recipientId;
                 _setRecipientStatus(recipientId, uint8(Status.Pending));
 

--- a/contracts/extensions/contracts/RecipientsExtension.sol
+++ b/contracts/extensions/contracts/RecipientsExtension.sol
@@ -163,6 +163,7 @@ abstract contract RecipientsExtension is CoreBaseStrategy, Errors, IRecipientsEx
     }
 
     function _validateReviewRecipients(address _sender) internal virtual {
+        _checkOnlyActiveRegistration();
         _checkOnlyPoolManager(_sender);
     }
 

--- a/contracts/extensions/interfaces/IRecipientsExtension.sol
+++ b/contracts/extensions/interfaces/IRecipientsExtension.sol
@@ -40,6 +40,8 @@ interface IRecipientsExtension {
         // If false, the recipientAddress is the anchor of the profile
         bool useRegistryAnchor;
         address recipientAddress;
+        // 'statusIndex' is the index of the recipient in the 'statusesBitMap' bitmap.
+        uint64 statusIndex;
         Metadata metadata;
     }
 

--- a/contracts/strategies/RFPSimple.sol
+++ b/contracts/strategies/RFPSimple.sol
@@ -34,6 +34,7 @@ contract RFPSimple is CoreBaseStrategy, MilestonesExtension, RecipientsExtension
     /// ========== Storage =============
     /// ================================
 
+    /// @notice set to true if the milestone id was already paid
     mapping(uint256 => bool) public wasMilestonePaid;
 
     /// ===============================
@@ -42,7 +43,7 @@ contract RFPSimple is CoreBaseStrategy, MilestonesExtension, RecipientsExtension
 
     /// @notice Constructor for the RFP Simple Strategy
     /// @param _allo The 'Allo' contract
-    constructor(address _allo) CoreBaseStrategy(_allo) RecipientsExtension(true) {}
+    constructor(address _allo) RecipientsExtension(_allo, true) {}
 
     /// ===============================
     /// ========= Initialize ==========
@@ -64,11 +65,6 @@ contract RFPSimple is CoreBaseStrategy, MilestonesExtension, RecipientsExtension
     /// ====================================
     /// ============ Internal ==============
     /// ====================================
-
-    function _validateReviewRecipients(address _sender) internal virtual override {
-        _checkOnlyActiveRegistration();
-        super._validateReviewRecipients(_sender);
-    }
 
     function _reviewRecipientStatus(Status _newStatus, Status _oldStatus, uint256 _recipientIndex)
         internal

--- a/contracts/strategies/RFPSimple.sol
+++ b/contracts/strategies/RFPSimple.sol
@@ -70,12 +70,18 @@ contract RFPSimple is CoreBaseStrategy, MilestonesExtension, RecipientsExtension
         super._validateReviewRecipients(_sender);
     }
 
-    function _reviewRecipientStatus(Status _newStatus, uint256) internal virtual override {
+    function _reviewRecipientStatus(Status _newStatus, Status _oldStatus, uint256 _recipientIndex)
+        internal
+        virtual
+        override
+        returns (Status _reviewedStatus)
+    {
         if (_newStatus == IRecipientsExtension.Status.Accepted) {
             if (block.timestamp > registrationEndTime) revert INVALID();
-            // THe registration pariod ends when a recipient is accepted.
+            // The registration period ends when a recipient is accepted.
             registrationEndTime = uint64(block.timestamp - 1);
         }
+        _reviewedStatus = _newStatus;
     }
 
     /// @notice Hook to process recipient data

--- a/foundry.toml
+++ b/foundry.toml
@@ -39,7 +39,10 @@ extra_output = ["storageLayout"]
 allow_paths = ['node_modules']
 
 [fmt]
-ignore = ['contracts/strategies/_poc/qv-hackathon/SchemaResolver.sol']
+ignore = [
+  'contracts/strategies/_poc/qv-hackathon/SchemaResolver.sol',
+  'contracts/strategies/_poc/direct-grants-simple/DirectGrantsSimpleStrategy.sol'
+]
 
 [rpc_endpoints]
 mainnet = "${MAINNET_RPC_URL}"

--- a/test/foundry/extensions/RecipientsExtension.t.sol
+++ b/test/foundry/extensions/RecipientsExtension.t.sol
@@ -260,7 +260,6 @@ contract RecipientsExtensionReviewRecipientStatus is BaseRecipientsExtensionUnit
             } else {
                 assertEq(newStatus, uint8(Status.Accepted));
             }
-            
         }
     }
 
@@ -272,9 +271,7 @@ contract RecipientsExtensionReviewRecipientStatus is BaseRecipientsExtensionUnit
             if (_statusValues[i] != 0) {
                 vm.expectEmit();
                 emit ReviewRecipientStatus(
-                    IRecipientsExtension.Status(_statusValues[i]),
-                    IRecipientsExtension.Status(0),
-                    i + 1
+                    IRecipientsExtension.Status(_statusValues[i]), IRecipientsExtension.Status(0), i + 1
                 );
             }
         }
@@ -282,11 +279,7 @@ contract RecipientsExtensionReviewRecipientStatus is BaseRecipientsExtensionUnit
         recipientsExtension.expose_processStatusRow(0, _fullRow, false);
     }
 
-    function _boundStatuses(uint256 _fullRow)
-        internal
-        view
-        returns (uint256, uint8[] memory)
-    {
+    function _boundStatuses(uint256 _fullRow) internal view returns (uint256, uint8[] memory) {
         uint8[] memory _statusValues = new uint8[](64);
         for (uint256 col = 0; col < 64; col++) {
             uint256 colIndex = col << 2; // col * 4

--- a/test/foundry/integration/RFPSimple.t.sol
+++ b/test/foundry/integration/RFPSimple.t.sol
@@ -37,7 +37,8 @@ contract IntegrationRFPSimple is Test {
         view
         returns (IRecipientsExtension.ApplicationStatus memory)
     {
-        uint256 recipientIndex = strategy.recipientToStatusIndexes(_recipientId) - 1;
+        IRecipientsExtension.Recipient memory recipient = strategy.getRecipient(_recipientId);
+        uint256 recipientIndex = recipient.statusIndex - 1;
 
         uint256 rowIndex = recipientIndex / 64;
         uint256 colIndex = (recipientIndex % 64) * 4;
@@ -53,11 +54,15 @@ contract IntegrationRFPSimple is Test {
         view
         returns (IRecipientsExtension.ApplicationStatus memory)
     {
-        uint256 recipientIndex = strategy.recipientToStatusIndexes(_recipientIds[0]) - 1;
+        IRecipientsExtension.Recipient memory recipient = strategy.getRecipient(_recipientIds[0]);
+        uint256 recipientIndex = recipient.statusIndex - 1;
         uint256 rowIndex = recipientIndex / 64;
         uint256 statusRow = strategy.statusesBitMap(rowIndex);
+
         for (uint256 i = 0; i < _recipientIds.length; i++) {
-            recipientIndex = strategy.recipientToStatusIndexes(_recipientIds[i]) - 1;
+            recipient = strategy.getRecipient(_recipientIds[i]);
+            recipientIndex = recipient.statusIndex - 1;
+
             require(rowIndex == recipientIndex / 64, "_recipientIds belong to different rows");
             uint256 colIndex = (recipientIndex % 64) * 4;
             uint256 newRow = statusRow & ~(15 << colIndex);

--- a/test/utils/MockStrategyRecipientsExtension.sol
+++ b/test/utils/MockStrategyRecipientsExtension.sol
@@ -8,7 +8,7 @@ import {Metadata} from "../../contracts/core/libraries/Metadata.sol";
 import {Test} from "forge-std/Test.sol";
 
 contract MockStrategyRecipientsExtension is CoreBaseStrategy, RecipientsExtension, Test {
-    constructor(address _allo) CoreBaseStrategy(_allo) {}
+    constructor(address _allo, bool _reviewEachStatus) RecipientsExtension(_allo, _reviewEachStatus) {}
 
     function initialize(uint256 _poolId, bytes memory _data) external {
         __BaseStrategy_init(_poolId);
@@ -459,8 +459,12 @@ contract MockStrategyRecipientsExtension is CoreBaseStrategy, RecipientsExtensio
         _recipients[_key0] = _value;
     }
 
-    function set_recipientToStatusIndexes(address _key0, uint256 _value) public {
-        recipientToStatusIndexes[_key0] = _value;
+    function set_recipientToStatusIndexes(address _key0, uint64 _value) public {
+        _recipients[_key0].statusIndex = _value;
+    }
+
+    function set_recipientIndexToRecipientId(uint256 _key0, address _value) public {
+        recipientIndexToRecipientId[_key0] = _value;
     }
 
     function set_statusesBitMap(uint256 _key0, uint256 _value) public {

--- a/test/utils/MockStrategyRecipientsExtension.sol
+++ b/test/utils/MockStrategyRecipientsExtension.sol
@@ -476,9 +476,13 @@ contract MockStrategyRecipientsExtension is CoreBaseStrategy, RecipientsExtensio
     }
 
     bool internal forceAccept;
+
     event ReviewRecipientStatus(Status _newStatus, Status _oldStatus, uint256 _recipientIndex);
 
-    function expose_processStatusRow(uint256 _rowIndex, uint256 _fullRow, bool _forceAccept) external returns(uint256) {
+    function expose_processStatusRow(uint256 _rowIndex, uint256 _fullRow, bool _forceAccept)
+        external
+        returns (uint256)
+    {
         forceAccept = _forceAccept;
         return _processStatusRow(_rowIndex, _fullRow);
     }

--- a/test/utils/MockStrategyRecipientsExtension.sol
+++ b/test/utils/MockStrategyRecipientsExtension.sol
@@ -474,4 +474,26 @@ contract MockStrategyRecipientsExtension is CoreBaseStrategy, RecipientsExtensio
     function set_metadataRequired(bool _metadataRequired) public {
         metadataRequired = _metadataRequired;
     }
+
+    bool internal forceAccept;
+    event ReviewRecipientStatus(Status _newStatus, Status _oldStatus, uint256 _recipientIndex);
+
+    function expose_processStatusRow(uint256 _rowIndex, uint256 _fullRow, bool _forceAccept) external returns(uint256) {
+        forceAccept = _forceAccept;
+        return _processStatusRow(_rowIndex, _fullRow);
+    }
+
+    function _reviewRecipientStatus(Status _newStatus, Status _oldStatus, uint256 _recipientIndex)
+        internal
+        virtual
+        override
+        returns (Status _reviewedStatus)
+    {
+        emit ReviewRecipientStatus(_newStatus, _oldStatus, _recipientIndex);
+        if (forceAccept) {
+            return Status.Accepted;
+        } else {
+            return super._reviewRecipientStatus(_newStatus, _oldStatus, _recipientIndex);
+        }
+    }
 }


### PR DESCRIPTION
The idea of these changes is that:
- It should be easy to add custom review logic to each new Status being set in `reviewRecipients()` (e.g. do sth on Status.Reject).
- It should be easy to differentiate a new Status from an old Status. Currently in `reviewRecipients()` it is not straight forward to see which statuses are new and which are not, because a row with 64 statuses is passed as param and set to storage directly.
- It should be possible and easy to access the recipient id of the new Status being set.
- It should be easy to override `reviewRecipients()` to use a different permission logic.
- We should keep the gas optimization of using a bitmap for recipients statuses.

Some ideas implemented so far:
- [x] merge and pack recipientToStatusIndexes into Recipient struct
- [x] add mapping containing the `recipientIndex` --> `recipientId` information.
- [x] iterate all the statuses in reviewRecipient and call an internal customizable function. Only if an immutable var was set to true to save gas when this is not needed.